### PR TITLE
Fixes #3

### DIFF
--- a/app/submit/SubmitPageClient.tsx
+++ b/app/submit/SubmitPageClient.tsx
@@ -102,9 +102,9 @@ function SimpleSubmitForm({
   const [description, setDescription] = useState('');
   const [imageUrl, setImageUrl] = useState('');
   // Use the canonical POINT_PRESETS from lib/types.ts so the initial value
-  // matches one of the dropdown options (see #2).
+  // matches one of the tile options (see #2 and the painted/lore tile change).
   const [points, setPoints] = useState<number>(
-    kind === 'painted' ? POINT_PRESETS.model[0].value : 2,
+    kind === 'painted' ? POINT_PRESETS.model[0].value : POINT_PRESETS.lore[0].value,
   );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -213,39 +213,55 @@ function SimpleSubmitForm({
         />
       </label>
 
-      <label className="block">
-        <span className="label">
-          {kind === 'painted' ? 'Unit Size' : 'Claimed points'}
-        </span>
-        <select
-          value={points}
-          onChange={(e) => setPoints(Number(e.target.value))}
-          className="input w-full bg-ink text-parchment"
-        >
-          {kind === 'painted'
-            ? POINT_PRESETS.model.map((opt) => (
-                <option
-                  key={opt.value}
-                  value={opt.value}
-                  className="bg-ink text-parchment"
-                >
-                  {opt.label} · {opt.value} pts
-                </option>
-              ))
-            : POINT_PRESETS.lore.map((opt) => (
-                <option
-                  key={opt.value}
-                  value={opt.value}
-                  className="bg-ink text-parchment"
-                >
-                  {opt.label} · {opt.value} pts
-                </option>
-              ))}
-        </select>
-        <p className="mt-1 text-xs italic text-parchment-dark">
-          The Inquisition may adjust this value upon review.
-        </p>
-      </label>
+      {kind === 'painted' ? (
+        <div>
+          <span className="label">Unit Size</span>
+          <div className="mt-1 grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3">
+            {POINT_PRESETS.model.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setPoints(opt.value)}
+                className={`flex flex-col items-center rounded border px-3 py-2 text-center text-sm transition-colors hover:border-brass/50 ${
+                  points === opt.value
+                    ? 'border-brass bg-brass/10 text-parchment'
+                    : 'border-brass/20 text-parchment-dim'
+                }`}
+              >
+                <span>{opt.label}</span>
+                <span className="text-xs opacity-80">{opt.value} pts</span>
+              </button>
+            ))}
+          </div>
+          <p className="mt-1 text-xs italic text-parchment-dark">
+            The Inquisition may adjust this value upon review.
+          </p>
+        </div>
+      ) : (
+        <div>
+          <span className="label">Claimed points</span>
+          <div className="mt-1 grid grid-cols-1 gap-2 sm:grid-cols-3">
+            {POINT_PRESETS.lore.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setPoints(opt.value)}
+                className={`flex flex-col items-center rounded border px-3 py-2 text-center text-sm transition-colors hover:border-brass/50 ${
+                  points === opt.value
+                    ? 'border-brass bg-brass/10 text-parchment'
+                    : 'border-brass/20 text-parchment-dim'
+                }`}
+              >
+                <span>{opt.label}</span>
+                <span className="text-xs opacity-80">{opt.value} pts</span>
+              </button>
+            ))}
+          </div>
+          <p className="mt-1 text-xs italic text-parchment-dark">
+            The Inquisition may adjust this value upon review.
+          </p>
+        </div>
+      )}
 
       {error && (
         <div className="border border-blood bg-blood/20 px-3 py-2 text-sm text-parchment">

--- a/components/AdversaryPicker.tsx
+++ b/components/AdversaryPicker.tsx
@@ -133,7 +133,7 @@ export default function AdversaryPicker({ value, onChange, currentUserId }: Prop
   return (
     <div ref={wrapRef} className="relative flex flex-col gap-2">
       <label className="block">
-        <span className="block text-sm font-medium text-parchment-200">Adversary</span>
+        <span className="label">Adversary</span>
         <div className="mt-1 flex items-stretch gap-2">
           <input
             type="text"
@@ -147,13 +147,13 @@ export default function AdversaryPicker({ value, onChange, currentUserId }: Prop
             }}
             onFocus={() => { if (suggestions.length > 0) setOpen(true); }}
             placeholder="Type a name — registered players will auto-suggest"
-            className="flex-1 rounded border border-brass-700/40 bg-parchment-950 px-3 py-2 text-parchment-100 placeholder:text-parchment-500 focus:border-brass-500 focus:outline-none"
+            className="input flex-1"
           />
           {value.userId && (
             <button
               type="button"
               onClick={clearLink}
-              className="rounded border border-brass-700/40 px-2 py-1 text-xs text-parchment-300 hover:text-brass-200"
+              className="rounded border border-brass/40 px-2 py-1 text-xs text-parchment-dim hover:border-brass hover:text-brass-bright"
               aria-label="Unlink opponent"
             >
               Unlink
@@ -163,30 +163,30 @@ export default function AdversaryPicker({ value, onChange, currentUserId }: Prop
       </label>
 
       {open && suggestions.length > 0 && (
-        <ul className="absolute top-full z-20 mt-1 w-full overflow-hidden rounded border border-brass-700/40 bg-parchment-900 shadow-lg">
+        <ul className="absolute top-full z-20 mt-1 w-full overflow-hidden rounded border border-brass/40 bg-ink-2 shadow-lg">
           {loadingSuggest && (
-            <li className="px-3 py-2 text-sm text-parchment-400">Searching…</li>
+            <li className="px-3 py-2 text-sm text-parchment-dark">Searching…</li>
           )}
           {suggestions.map((s) => (
             <li key={s.id}>
               <button
                 type="button"
                 onClick={() => pick(s)}
-                className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-brass-700/20"
+                className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-brass/10"
               >
-                <div className="h-7 w-7 shrink-0 overflow-hidden rounded-full border border-brass-700/40 bg-parchment-800">
+                <div className="h-7 w-7 shrink-0 overflow-hidden rounded-full border border-brass/40 bg-ink">
                   {s.avatar_url ? (
                     // eslint-disable-next-line @next/next/no-img-element
                     <img src={s.avatar_url} alt="" className="h-full w-full object-cover" />
                   ) : (
-                    <div className="flex h-full w-full items-center justify-center text-xs text-brass-300">
+                    <div className="flex h-full w-full items-center justify-center text-xs text-brass-bright">
                       {s.display_name.charAt(0).toUpperCase()}
                     </div>
                   )}
                 </div>
-                <span className="text-sm text-parchment-100">{s.display_name}</span>
+                <span className="text-sm text-parchment">{s.display_name}</span>
                 {s.primary_faction_name && (
-                  <span className="ml-auto text-xs text-parchment-400">{s.primary_faction_name}</span>
+                  <span className="ml-auto text-xs text-parchment-dark">{s.primary_faction_name}</span>
                 )}
               </button>
             </li>
@@ -205,16 +205,16 @@ export default function AdversaryPicker({ value, onChange, currentUserId }: Prop
             <label className="mt-2 block">
               <span className="block text-xs text-green-200">Which faction were they fielding?</span>
               <select
-                className="mt-1 w-full rounded border border-brass-700/40 bg-parchment-950 px-2 py-1 text-parchment-100"
+                className="input mt-1 w-full bg-ink text-parchment"
                 value={value.factionId ?? ''}
                 onChange={(e) => {
                   const f = opponentFactions.find((x) => x.id === e.target.value);
                   onChange({ ...value, factionId: f?.id ?? null, factionName: f?.name ?? null });
                 }}
               >
-                <option value="">— select faction —</option>
+                <option value="" className="bg-ink text-parchment">— select faction —</option>
                 {opponentFactions.map((f) => (
-                  <option key={f.id} value={f.id}>{f.name}</option>
+                  <option key={f.id} value={f.id} className="bg-ink text-parchment">{f.name}</option>
                 ))}
               </select>
             </label>


### PR DESCRIPTION
Replaces both preset-point <select> controls on the painted and lore submission forms with grids of tappable tiles, matching the Battle Size / Result tile patterns already used by BattleSubmitForm. Clicking a tile sets the claimed points to that preset's value and highlights it with the standard active-state treatment (border-brass bg-brass/10 text-parchment).
Grid responsiveness scales with option count:

Painted (6 options from POINT_PRESETS.model): grid-cols-1 → sm:grid-cols-2 → md:grid-cols-3 — 2×3 on desktop.
Lore (3 options from POINT_PRESETS.lore): grid-cols-1 → sm:grid-cols-3 — single row at sm+, matching Battle Size exactly.

Each tile is a two-line button with label on top and "N pts" below, same as the Result tiles in BattleSubmitForm.
Also fixes a latent default-value bug surfaced by this change: the form initialized points to 2 for lore, but 2 isn't a member of POINT_PRESETS.lore ([3, 6, 10]). Invisible with the dropdown; with tiles it would mean no tile was highlighted on load. Now initializes to POINT_PRESETS.lore[0].value so a tile is always pre-selected.
Pure presentation — no submission-payload changes.