### PR TITLE
Activity feed: thumbnails, detail page, styling sweep

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { FactionTotal, PlayerTotal } from "@/lib/types";
@@ -97,7 +98,14 @@ export default async function LeaderboardPage() {
               {pt.map((p, i) => (
                 <tr key={p.player_id} className="border-b border-brass/5 hover:bg-brass/5">
                   <td className="p-3 font-display text-brass">{i + 1}</td>
-                  <td className="p-3 font-display text-parchment">{p.display_name}</td>
+                  <td className="p-3 font-display">
+                    <Link
+                      href={`/player/${p.player_id}`}
+                      className="text-parchment hover:text-brass-bright transition-colors"
+                    >
+                      {p.display_name}
+                    </Link>
+                  </td>
                   <td className="p-3 hidden sm:table-cell" style={{ color: p.faction_color ?? "#b8a888" }}>
                     {p.faction_name ?? "—"}
                   </td>

--- a/app/submission/[id]/page.tsx
+++ b/app/submission/[id]/page.tsx
@@ -1,0 +1,196 @@
+// =====================================================================
+// app/submission/[id]/page.tsx
+// Public detail page for a single approved deed. Shows full title,
+// untruncated description, full-size uncropped image, and all the
+// metadata that the activity feed card only previews.
+//
+// Queries from activity_feed, which already filters status='approved',
+// so unapproved submissions 404 rather than leak.
+// =====================================================================
+
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import type { ActivityFeedItem } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric', month: 'long', day: 'numeric',
+  });
+}
+
+const KIND_LABELS: Record<string, { label: string; icon: string }> = {
+  battle:  { label: 'Battle Report', icon: '⚔' },
+  painted: { label: 'Painted',       icon: '🖌' },
+  lore:    { label: 'Lore',          icon: '📜' },
+  bonus:   { label: 'Bonus',         icon: '✦' },
+};
+
+export default async function SubmissionDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data } = await supabase
+    .from('activity_feed')
+    .select('*')
+    .eq('submission_id', id)
+    .maybeSingle();
+
+  if (!data) notFound();
+  const it = data as ActivityFeedItem;
+
+  const kindMeta = KIND_LABELS[it.kind] ?? { label: it.kind, icon: '✠' };
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-8 sm:px-6 sm:py-12">
+      {/* Breadcrumb / back link */}
+      <Link
+        href="/"
+        className="inline-flex items-center gap-1 text-sm text-parchment-dim hover:text-brass-bright transition-colors"
+      >
+        ← Back to the chronicle
+      </Link>
+
+      <article className="mt-6 card p-6 sm:p-8">
+        {/* Header: kind, faction, date */}
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <span className="inline-flex items-center gap-1 rounded-full border border-brass/40 bg-brass/10 px-2 py-0.5 text-xs font-display uppercase tracking-wider text-brass-bright">
+            <span aria-hidden>{kindMeta.icon}</span> {kindMeta.label}
+          </span>
+          {it.result && (
+            <span
+              className={`rounded border px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
+                it.result === 'win'
+                  ? 'border-green-700/60 bg-green-900/30 text-green-200'
+                  : it.result === 'loss'
+                  ? 'border-red-700/60 bg-red-900/30 text-red-200'
+                  : 'border-yellow-700/60 bg-yellow-900/30 text-yellow-200'
+              }`}
+            >
+              {it.result}
+            </span>
+          )}
+          {it.faction_name && (
+            <span
+              className="rounded px-1.5 py-0.5 text-xs font-medium text-parchment"
+              style={{ backgroundColor: it.faction_color ?? '#7a5b20' }}
+            >
+              {it.faction_name}
+            </span>
+          )}
+          <span className="ml-auto text-xs text-parchment-dark">
+            {formatDate(it.created_at)}
+          </span>
+        </div>
+
+        {/* Title */}
+        {it.title && (
+          <h1 className="mt-4 font-display text-3xl tracking-wider text-parchment">
+            {it.title}
+          </h1>
+        )}
+
+        {/* Byline */}
+        <div className="mt-3 flex flex-wrap items-center gap-2 text-sm text-parchment-dim">
+          <span>by</span>
+          {it.user_id ? (
+            <Link
+              href={`/player/${it.user_id}`}
+              className="font-display text-parchment hover:text-brass-bright transition-colors"
+            >
+              {it.display_name}
+            </Link>
+          ) : (
+            <span className="font-display text-parchment">{it.display_name}</span>
+          )}
+        </div>
+
+        {/* Full-size image — object-contain so nothing gets cropped. */}
+        {it.image_url && (
+          <div className="mt-6 overflow-hidden rounded border border-brass/30 bg-ink">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={it.image_url}
+              alt={it.title ?? 'Submission image'}
+              className="mx-auto block max-h-[70vh] w-auto object-contain"
+            />
+          </div>
+        )}
+
+        {/* Description / lore body */}
+        {it.description && (
+          <div className="mt-6 whitespace-pre-wrap font-body text-base leading-relaxed text-parchment">
+            {it.description}
+          </div>
+        )}
+
+        {/* Metadata panel */}
+        <dl className="mt-8 grid grid-cols-1 gap-x-6 gap-y-3 border-t border-brass/20 pt-6 text-sm sm:grid-cols-2">
+          {it.planet_name && (
+            <div>
+              <dt className="label">World</dt>
+              <dd className="mt-0.5">
+                <Link
+                  href={`/map?planet=${it.planet_id}`}
+                  className="text-parchment hover:text-brass-bright transition-colors"
+                >
+                  ◈ {it.planet_name}
+                </Link>
+              </dd>
+            </div>
+          )}
+          {it.adversary_name && (
+            <div>
+              <dt className="label">Adversary</dt>
+              <dd className="mt-0.5">
+                {it.adversary_user_id ? (
+                  <Link
+                    href={`/player/${it.adversary_user_id}`}
+                    className="text-parchment hover:text-brass-bright transition-colors"
+                  >
+                    {it.adversary_name}
+                  </Link>
+                ) : (
+                  <span className="text-parchment">{it.adversary_name}</span>
+                )}
+                {it.adversary_faction_name && (
+                  <span className="text-parchment-dim"> · {it.adversary_faction_name}</span>
+                )}
+              </dd>
+            </div>
+          )}
+          {it.game_system_name && (
+            <div>
+              <dt className="label">Game System</dt>
+              <dd className="mt-0.5 text-parchment">{it.game_system_name}</dd>
+            </div>
+          )}
+          {it.video_game_name && (
+            <div>
+              <dt className="label">Video Game</dt>
+              <dd className="mt-0.5 text-parchment">🎮 {it.video_game_name}</dd>
+            </div>
+          )}
+          {it.game_size && it.game_size !== 'n/a' && (
+            <div>
+              <dt className="label">Battle Size</dt>
+              <dd className="mt-0.5 capitalize text-parchment">{it.game_size}</dd>
+            </div>
+          )}
+          {it.points !== null && it.points > 0 && (
+            <div>
+              <dt className="label">Glory Earned</dt>
+              <dd className="mt-0.5 font-display text-brass-bright">+{it.points}</dd>
+            </div>
+          )}
+        </dl>
+      </article>
+    </main>
+  );
+}

--- a/components/ActivityFeed.tsx
+++ b/components/ActivityFeed.tsx
@@ -5,7 +5,6 @@
 // =====================================================================
 
 import Link from 'next/link';
-import Image from 'next/image';
 import { createClient } from '@/lib/supabase/server';
 import type { ActivityFeedItem } from '@/lib/types';
 
@@ -33,7 +32,7 @@ function KindBadge({ kind }: { kind: string }) {
     lore:    { label: 'Lore',    cls: 'border-amber-700/60 bg-amber-900/30 text-amber-200',  icon: '📜' },
     bonus:   { label: 'Bonus',   cls: 'border-purple-700/60 bg-purple-900/30 text-purple-200', icon: '✦' },
   };
-  const cfg = map[kind] ?? { label: kind, cls: 'border-brass-700/60 bg-brass-900/30 text-brass-200', icon: '✠' };
+  const cfg = map[kind] ?? { label: kind, cls: 'border-brass/40 bg-brass/20 text-brass-bright', icon: '✠' };
   return (
     <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${cfg.cls}`}>
       <span aria-hidden>{cfg.icon}</span> {cfg.label}
@@ -66,7 +65,7 @@ export default async function ActivityFeed({ limit = 15 }: { limit?: number }) {
 
   if (error) {
     return (
-      <div className="rounded border border-brass-700/40 bg-parchment-900/40 p-4 text-sm text-parchment-300">
+      <div className="card p-4 text-sm text-parchment-dim">
         Unable to load the activity feed right now.
       </div>
     );
@@ -76,8 +75,8 @@ export default async function ActivityFeed({ limit = 15 }: { limit?: number }) {
 
   if (items.length === 0) {
     return (
-      <div className="rounded border border-brass-700/40 bg-parchment-900/40 p-6 text-center text-parchment-300">
-        <p className="font-cinzel text-lg text-brass-200">The archives are silent.</p>
+      <div className="card p-6 text-center text-parchment-dim">
+        <p className="font-display text-lg text-brass-bright">The archives are silent.</p>
         <p className="mt-1 text-sm">No deeds have been chronicled yet. Be the first to make history.</p>
       </div>
     );
@@ -88,38 +87,49 @@ export default async function ActivityFeed({ limit = 15 }: { limit?: number }) {
       {items.map((it) => (
         <article
           key={it.submission_id}
-          className="group flex flex-col gap-3 rounded border border-brass-700/40 bg-parchment-900/50 p-4 transition-colors hover:border-brass-600 sm:flex-row"
+          className="group relative flex flex-col gap-3 rounded border border-brass/20 bg-ink-2/60 p-4 transition-colors hover:border-brass/60 sm:flex-row"
         >
-          {/* Avatar / image */}
-          <div className="flex shrink-0 items-start gap-3 sm:flex-col sm:items-center">
+          {/* Stretched overlay link — makes the whole card clickable.
+              Inner <Link> elements sit above this via relative z-10 so
+              they still get their own click targets (player profile,
+              planet page, adversary profile). The rounded + inset ring
+              appears on keyboard focus so tab-navigation is visible. */}
+          <Link
+            href={`/submission/${it.submission_id}`}
+            aria-label={`View details: ${it.title ?? 'deed'}`}
+            className="absolute inset-0 z-0 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-brass focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+          />
+
+          {/* Avatar */}
+          <div className="relative z-10 flex shrink-0 items-start gap-3 sm:flex-col sm:items-center">
             <Link
               href={it.user_id ? `/player/${it.user_id}` : '#'}
-              className="block h-12 w-12 shrink-0 overflow-hidden rounded-full border border-brass-700/50 bg-parchment-800"
+              className="block h-12 w-12 shrink-0 overflow-hidden rounded-full border border-brass/50 bg-ink-2"
             >
               {it.avatar_url ? (
                 // Using <img> rather than next/image so external URLs don't need next.config.js tweaks.
                 // eslint-disable-next-line @next/next/no-img-element
                 <img src={it.avatar_url} alt={it.display_name} className="h-full w-full object-cover" />
               ) : (
-                <div className="flex h-full w-full items-center justify-center font-cinzel text-brass-300">
+                <div className="flex h-full w-full items-center justify-center font-display text-brass">
                   {it.display_name.charAt(0).toUpperCase()}
                 </div>
               )}
             </Link>
           </div>
 
-          <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <div className="relative z-10 flex min-w-0 flex-1 flex-col gap-2">
             {/* Header row */}
             <div className="flex flex-wrap items-center gap-2 text-sm">
               <Link
                 href={it.user_id ? `/player/${it.user_id}` : '#'}
-                className="font-cinzel text-brass-100 hover:text-brass-300"
+                className="font-display text-parchment hover:text-brass-bright transition-colors"
               >
                 {it.display_name}
               </Link>
               {it.faction_name && (
                 <span
-                  className="rounded px-1.5 py-0.5 text-xs font-medium text-parchment-100"
+                  className="rounded px-1.5 py-0.5 text-xs font-medium text-parchment"
                   style={{ backgroundColor: it.faction_color ?? '#7a5b20' }}
                 >
                   {it.faction_name}
@@ -128,27 +138,29 @@ export default async function ActivityFeed({ limit = 15 }: { limit?: number }) {
               <KindBadge kind={it.kind} />
               {it.result && <ResultBadge result={it.result} />}
               {it.game_system_short && (
-                <span className="rounded border border-brass-700/40 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-brass-300">
+                <span className="rounded border border-brass/40 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-brass">
                   {it.game_system_short}
                 </span>
               )}
-              <span className="ml-auto shrink-0 text-xs text-parchment-400">{timeAgo(it.created_at)}</span>
+              <span className="ml-auto shrink-0 text-xs text-parchment-dark">{timeAgo(it.created_at)}</span>
             </div>
 
             {/* Title / description */}
             {it.title && (
-              <p className="font-cinzel text-base text-parchment-100">{it.title}</p>
+              <p className="font-display text-base text-parchment group-hover:text-brass-bright transition-colors">
+                {it.title}
+              </p>
             )}
             {it.description && (
-              <p className="line-clamp-3 text-sm text-parchment-200">{it.description}</p>
+              <p className="line-clamp-3 text-sm text-parchment-dim">{it.description}</p>
             )}
 
             {/* Metadata row */}
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-parchment-300">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-parchment-dim">
               {it.planet_name && (
                 <span>
-                  <span className="text-brass-400">◈</span>{' '}
-                  <Link href={`/map?planet=${it.planet_id}`} className="hover:text-brass-200">
+                  <span className="text-brass">◈</span>{' '}
+                  <Link href={`/map?planet=${it.planet_id}`} className="relative z-10 hover:text-brass-bright">
                     {it.planet_name}
                   </Link>
                 </span>
@@ -158,37 +170,42 @@ export default async function ActivityFeed({ limit = 15 }: { limit?: number }) {
                   vs{' '}
                   <Link
                     href={it.adversary_user_id ? `/player/${it.adversary_user_id}` : '#'}
-                    className="text-brass-200 hover:text-brass-100"
+                    className="relative z-10 text-parchment hover:text-brass-bright"
                   >
                     {it.adversary_name}
                   </Link>
                   {it.adversary_faction_name && (
-                    <span className="text-parchment-400"> ({it.adversary_faction_name})</span>
+                    <span className="text-parchment-dark"> ({it.adversary_faction_name})</span>
                   )}
                 </span>
               )}
               {it.video_game_name && (
-                <span className="text-parchment-400">🎮 {it.video_game_name}</span>
+                <span className="text-parchment-dark">🎮 {it.video_game_name}</span>
               )}
               {it.game_size && it.game_size !== 'n/a' && (
-                <span className="capitalize text-parchment-400">{it.game_size} battle</span>
+                <span className="capitalize text-parchment-dark">{it.game_size} battle</span>
               )}
               {it.points !== null && it.points > 0 && (
-                <span className="text-brass-300">+{it.points} glory</span>
+                <span className="text-brass-bright">+{it.points} glory</span>
               )}
             </div>
+          </div>
 
-            {/* Image */}
-            {it.image_url && (
-              // eslint-disable-next-line @next/next/no-img-element
+          {/* Thumbnail preview (right side on desktop, below content on mobile).
+              Small fixed 5rem square rather than a 100%-wide letterbox —
+              avoids the "cropped midsection" effect on portrait model
+              photos. Click the card to see the full uncropped image. */}
+          {it.image_url && (
+            <div className="relative z-10 shrink-0 self-start overflow-hidden rounded border border-brass/30 sm:order-last">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={it.image_url}
                 alt={it.title ?? 'Submission'}
-                className="mt-1 max-h-80 w-full rounded border border-brass-700/30 object-cover"
+                className="h-20 w-20 object-cover sm:h-24 sm:w-24"
                 loading="lazy"
               />
-            )}
-          </div>
+            </div>
+          )}
         </article>
       ))}
     </div>


### PR DESCRIPTION
Fixes two bugs on the activity feed and cleans up the file's styling while I'm here.

Thumbnails instead of full-width cropped image bars. Small square preview on each card; full uncropped image moves to the detail page.
Clickable cards → new /submission/[id] route showing full title, uncropped image, untruncated description, and all metadata. Uses the stretched-link pattern so inner links (player profile, planet, adversary) still work. Queries from activity_feed, which is already approved-only.
Styling sweep. Replaced the file's purged numeric-scale tokens (bg-parchment-900, text-parchment-200, font-cinzel, etc.) with the project's named palette (bg-ink-2, text-parchment-dim, font-display).