### PR TITLE
Fix #14: Minor text updates — Campaign Chronicle, Painted Unit

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import "./globals.css";
 import { NavBar } from "@/components/NavBar";
 
 export const metadata: Metadata = {
-  title: "Crusade Ledger — Campaign of the Burning Star",
+  title: "Campaign Chronicle — Campaign of the Burning Star",
   description:
     "Record your victories. Claim the stars. A Warhammer 40,000 campaign tracker.",
 };

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -48,7 +48,7 @@ export default async function LeaderboardPage() {
                 <th className="text-left p-3 w-12">#</th>
                 <th className="text-left p-3">Faction</th>
                 <th className="text-right p-3 hidden sm:table-cell">Wins</th>
-                <th className="text-right p-3 hidden md:table-cell">Models</th>
+                <th className="text-right p-3 hidden md:table-cell">Painted Units</th>
                 <th className="text-right p-3 hidden md:table-cell">Tales</th>
                 <th className="text-right p-3 hidden sm:table-cell">Worlds</th>
                 <th className="text-right p-3">Glory</th>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,7 +19,7 @@ export default function HomePage() {
         </div>
         <div className="relative">
           <p className="font-cinzel text-xs uppercase tracking-[0.3em] text-brass-300">
-            ✠ The Crusade Ledger ✠
+            ✠ The Campaign Chronicle ✠
           </p>
           <h1 className="mt-2 font-cinzel text-3xl text-brass-100 sm:text-5xl">
             Record your victories.<br className="hidden sm:block" /> Claim the stars.

--- a/app/submit/SubmitForm.tsx
+++ b/app/submit/SubmitForm.tsx
@@ -18,7 +18,7 @@ const TYPE_LABELS: Record<SubmissionType, { title: string; desc: string }> = {
     desc: "Record the outcome of a tabletop engagement.",
   },
   model: {
-    title: "Painted Model",
+    title: "Painted Unit",
     desc: "Show the work of your brushes. Points awarded per scale.",
   },
   lore: {

--- a/app/submit/SubmitPageClient.tsx
+++ b/app/submit/SubmitPageClient.tsx
@@ -27,7 +27,7 @@ interface Props {
 
 const KINDS: Array<{ id: Kind; label: string; icon: string; desc: string }> = [
   { id: 'battle',  label: 'Battle Report', icon: '⚔', desc: 'Log a game and claim glory on a world.' },
-  { id: 'painted', label: 'Painted Model', icon: '🖌', desc: 'Share miniatures you finished painting.' },
+  { id: 'painted', label: 'Painted Unit', icon: '🖌', desc: 'Share miniatures you finished painting.' },
   { id: 'lore',    label: 'Lore',          icon: '📜', desc: 'Write a piece of campaign fiction.' },
 ];
 

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -83,7 +83,7 @@ export function NavBar() {
           className="flex items-center gap-2 font-cinzel text-lg font-bold tracking-wide text-brass-100 sm:text-xl"
         >
           <span aria-hidden className="text-brass-400">✠</span>
-          <span>Crusade Ledger</span>
+          <span>Campaign Chronicle</span>
         </Link>
 
         {/* Desktop nav */}


### PR DESCRIPTION
Closes #14

## Changes
- Leaderboard: renamed **Models** column header → **Painted Units**
- NavBar, home page hero, and page `<title>`: renamed **Crusade Ledger** → **Campaign Chronicle**
- Submit page tile and form: renamed **Painted Model** → **Painted Unit**

## Files changed
- `app/layout.tsx`
- `app/leaderboard/page.tsx`
- `app/page.tsx`
- `app/submit/SubmitForm.tsx`
- `app/submit/SubmitPageClient.tsx`
- `components/NavBar.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)