### PR TITLE
Fix #12: Deed cards on dashboard and profile link to submission detail

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -151,15 +151,20 @@ export default async function DashboardPage() {
         ) : (
           <ul className="mt-3 flex flex-col divide-y divide-brass-700/20">
             {subs.map((s) => (
-              <li key={s.id} className="flex flex-wrap items-center gap-2 py-2 text-sm">
-                <span className="rounded bg-brass-700/30 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-brass-100">
+              <li key={s.id} className="relative flex flex-wrap items-center gap-2 py-2 text-sm hover:bg-brass-700/10 transition-colors">
+                <Link
+                  href={`/submission/${s.id}`}
+                  aria-label={`View deed: ${s.title ?? s.kind}`}
+                  className="absolute inset-0 z-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-brass focus-visible:ring-inset"
+                />
+                <span className="relative z-10 rounded bg-brass-700/30 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-brass-100">
                   {s.kind}
                 </span>
-                <span className="text-parchment-100">{s.title ?? '(untitled)'}</span>
+                <span className="relative z-10 text-parchment-100">{s.title ?? '(untitled)'}</span>
                 {s.planets?.name && (
-                  <span className="text-parchment-400">· {s.planets.name}</span>
+                  <span className="relative z-10 text-parchment-400">· {s.planets.name}</span>
                 )}
-                <span className={`ml-auto rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
+                <span className={`relative z-10 ml-auto rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
                   s.status === 'approved' ? 'bg-green-900/40 text-green-200'
                   : s.status === 'rejected' ? 'bg-red-900/40 text-red-200'
                   : 'bg-yellow-900/40 text-yellow-200'
@@ -167,9 +172,9 @@ export default async function DashboardPage() {
                   {s.status}
                 </span>
                 {s.points !== null && (
-                  <span className="text-xs text-brass-300">+{s.points}</span>
+                  <span className="relative z-10 text-xs text-brass-300">+{s.points}</span>
                 )}
-                <span className="w-full text-right text-[10px] text-parchment-400 sm:w-auto">
+                <span className="relative z-10 w-full text-right text-[10px] text-parchment-400 sm:w-auto">
                   {new Date(s.created_at).toLocaleDateString()}
                 </span>
               </li>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import FactionMembership from '@/components/FactionMembership';
+import KindBadge from '@/components/KindBadge';
 
 export const dynamic = 'force-dynamic';
 
@@ -151,20 +152,20 @@ export default async function DashboardPage() {
         ) : (
           <ul className="mt-3 flex flex-col divide-y divide-brass-700/20">
             {subs.map((s) => (
-              <li key={s.id} className="relative flex flex-wrap items-center gap-2 py-2 text-sm hover:bg-brass-700/10 transition-colors">
+              <li key={s.id} className="group relative flex flex-wrap items-center gap-2 px-2 py-2 text-sm transition-colors hover:bg-brass/10">
+                {/* Stretched overlay sits on top so clicks anywhere on the row navigate.
+                    No inner links exist here, so a single overlay is sufficient. */}
                 <Link
                   href={`/submission/${s.id}`}
                   aria-label={`View deed: ${s.title ?? s.kind}`}
-                  className="absolute inset-0 z-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-brass focus-visible:ring-inset"
+                  className="absolute inset-0 z-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brass focus-visible:ring-inset"
                 />
-                <span className="relative z-10 rounded bg-brass-700/30 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-brass-100">
-                  {s.kind}
-                </span>
-                <span className="relative z-10 text-parchment-100">{s.title ?? '(untitled)'}</span>
+                <KindBadge kind={s.kind} />
+                <span className="text-parchment transition-colors group-hover:text-brass-bright">{s.title ?? '(untitled)'}</span>
                 {s.planets?.name && (
-                  <span className="relative z-10 text-parchment-400">· {s.planets.name}</span>
+                  <span className="text-parchment-400">· {s.planets.name}</span>
                 )}
-                <span className={`relative z-10 ml-auto rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
+                <span className={`ml-auto rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
                   s.status === 'approved' ? 'bg-green-900/40 text-green-200'
                   : s.status === 'rejected' ? 'bg-red-900/40 text-red-200'
                   : 'bg-yellow-900/40 text-yellow-200'
@@ -172,9 +173,9 @@ export default async function DashboardPage() {
                   {s.status}
                 </span>
                 {s.points !== null && (
-                  <span className="relative z-10 text-xs text-brass-300">+{s.points}</span>
+                  <span className="text-xs text-brass-300">+{s.points}</span>
                 )}
-                <span className="relative z-10 w-full text-right text-[10px] text-parchment-400 sm:w-auto">
+                <span className="w-full text-right text-[10px] text-parchment-400 sm:w-auto">
                   {new Date(s.created_at).toLocaleDateString()}
                 </span>
               </li>

--- a/app/player/[id]/page.tsx
+++ b/app/player/[id]/page.tsx
@@ -10,6 +10,7 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
+import KindBadge from '@/components/KindBadge';
 import type { ActivityFeedItem } from '@/lib/types';
 
 interface PageProps {
@@ -209,15 +210,21 @@ export default async function PlayerProfilePage({ params }: PageProps) {
             {activityRows.map((a) => (
               <li
                 key={a.submission_id}
-                className="group flex gap-3 rounded border border-brass-700/40 bg-parchment-900/50 p-3 transition-colors hover:border-brass-500/60 hover:bg-brass-700/10"
+                className="group relative flex gap-3 rounded border border-brass/30 bg-ink-2/60 p-3 transition-colors hover:border-brass/60 hover:bg-brass/10"
               >
+                {/* Stretched overlay: a real anchor sits above all content so clicks
+                    anywhere on the card navigate to the submission detail. Inner
+                    links (planet, adversary) are bumped to z-20 to remain clickable. */}
+                <Link
+                  href={`/submission/${a.submission_id}`}
+                  aria-label={`View deed: ${a.title ?? a.kind}`}
+                  className="absolute inset-0 z-10 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-brass focus-visible:ring-inset"
+                />
                 <div className="flex min-w-0 flex-1 flex-col gap-2">
-                  <div className="flex flex-wrap items-center gap-2 text-xs text-parchment-300">
-                    <span className="rounded bg-brass-700/30 px-1.5 py-0.5 font-bold uppercase tracking-wider text-brass-100">
-                      {a.kind}
-                    </span>
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-parchment-dim">
+                    <KindBadge kind={a.kind} />
                     {a.game_system_short && (
-                      <span className="rounded border border-brass-700/40 px-1.5 py-0.5 uppercase">
+                      <span className="rounded border border-brass/40 px-1.5 py-0.5 uppercase">
                         {a.game_system_short}
                       </span>
                     )}
@@ -231,7 +238,7 @@ export default async function PlayerProfilePage({ params }: PageProps) {
                       </span>
                     )}
                     {a.planet_name && (
-                      <Link href={`/map?planet=${a.planet_id}`} className="text-brass-300 hover:text-brass-100">
+                      <Link href={`/map?planet=${a.planet_id}`} className="relative z-20 text-brass hover:text-brass-bright">
                         ◈ {a.planet_name}
                       </Link>
                     )}
@@ -240,36 +247,33 @@ export default async function PlayerProfilePage({ params }: PageProps) {
                         vs{' '}
                         <Link
                           href={a.adversary_user_id ? `/player/${a.adversary_user_id}` : '#'}
-                          className="text-brass-300 hover:text-brass-100"
+                          className="relative z-20 text-brass hover:text-brass-bright"
                         >
                           {a.adversary_name}
                         </Link>
                       </span>
                     )}
-                    <span className="ml-auto text-parchment-400">
+                    <span className="ml-auto text-parchment-dark">
                       {new Date(a.created_at).toLocaleDateString()}
                     </span>
                   </div>
                   {a.title && (
-                    <Link
-                      href={`/submission/${a.submission_id}`}
-                      className="font-cinzel text-parchment-100 hover:text-brass-200 transition-colors"
-                    >
+                    <p className="font-display text-parchment transition-colors group-hover:text-brass-bright">
                       {a.title}
-                    </Link>
+                    </p>
                   )}
-                  {a.description && <p className="text-sm text-parchment-300">{a.description}</p>}
+                  {a.description && <p className="text-sm text-parchment-dim">{a.description}</p>}
                 </div>
                 {a.image_url && (
-                  <Link href={`/submission/${a.submission_id}`} className="shrink-0 self-start">
+                  <div className="shrink-0 self-start">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={a.image_url}
                       alt={a.title ?? 'Deed image'}
-                      className="h-20 w-20 rounded border border-brass-700/40 object-cover"
+                      className="h-20 w-20 rounded border border-brass/40 object-cover"
                       loading="lazy"
                     />
-                  </Link>
+                  </div>
                 )}
               </li>
             ))}

--- a/app/player/[id]/page.tsx
+++ b/app/player/[id]/page.tsx
@@ -209,14 +209,9 @@ export default async function PlayerProfilePage({ params }: PageProps) {
             {activityRows.map((a) => (
               <li
                 key={a.submission_id}
-                className="group relative rounded border border-brass-700/40 bg-parchment-900/50 p-3 transition-colors hover:border-brass-500/60 hover:bg-brass-700/10"
+                className="group flex gap-3 rounded border border-brass-700/40 bg-parchment-900/50 p-3 transition-colors hover:border-brass-500/60 hover:bg-brass-700/10"
               >
-                <Link
-                  href={`/submission/${a.submission_id}`}
-                  aria-label={`View deed: ${a.title ?? a.kind}`}
-                  className="absolute inset-0 z-0 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-brass focus-visible:ring-inset"
-                />
-                <div className="relative z-10 flex flex-col gap-2">
+                <div className="flex min-w-0 flex-1 flex-col gap-2">
                   <div className="flex flex-wrap items-center gap-2 text-xs text-parchment-300">
                     <span className="rounded bg-brass-700/30 px-1.5 py-0.5 font-bold uppercase tracking-wider text-brass-100">
                       {a.kind}
@@ -255,9 +250,27 @@ export default async function PlayerProfilePage({ params }: PageProps) {
                       {new Date(a.created_at).toLocaleDateString()}
                     </span>
                   </div>
-                  {a.title && <p className="font-cinzel text-parchment-100 group-hover:text-brass-200 transition-colors">{a.title}</p>}
+                  {a.title && (
+                    <Link
+                      href={`/submission/${a.submission_id}`}
+                      className="font-cinzel text-parchment-100 hover:text-brass-200 transition-colors"
+                    >
+                      {a.title}
+                    </Link>
+                  )}
                   {a.description && <p className="text-sm text-parchment-300">{a.description}</p>}
                 </div>
+                {a.image_url && (
+                  <Link href={`/submission/${a.submission_id}`} className="shrink-0 self-start">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={a.image_url}
+                      alt={a.title ?? 'Deed image'}
+                      className="h-20 w-20 rounded border border-brass-700/40 object-cover"
+                      loading="lazy"
+                    />
+                  </Link>
+                )}
               </li>
             ))}
           </ul>

--- a/app/player/[id]/page.tsx
+++ b/app/player/[id]/page.tsx
@@ -209,53 +209,55 @@ export default async function PlayerProfilePage({ params }: PageProps) {
             {activityRows.map((a) => (
               <li
                 key={a.submission_id}
-                className="group relative rounded border border-brass-700/40 bg-parchment-900/50 p-3 transition-colors hover:border-brass-500/60"
+                className="group relative rounded border border-brass-700/40 bg-parchment-900/50 p-3 transition-colors hover:border-brass-500/60 hover:bg-brass-700/10"
               >
                 <Link
                   href={`/submission/${a.submission_id}`}
                   aria-label={`View deed: ${a.title ?? a.kind}`}
                   className="absolute inset-0 z-0 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-brass focus-visible:ring-inset"
                 />
-                <div className="relative z-10 flex flex-wrap items-center gap-2 text-xs text-parchment-300">
-                  <span className="rounded bg-brass-700/30 px-1.5 py-0.5 font-bold uppercase tracking-wider text-brass-100">
-                    {a.kind}
-                  </span>
-                  {a.game_system_short && (
-                    <span className="rounded border border-brass-700/40 px-1.5 py-0.5 uppercase">
-                      {a.game_system_short}
+                <div className="relative z-10 flex flex-col gap-2">
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-parchment-300">
+                    <span className="rounded bg-brass-700/30 px-1.5 py-0.5 font-bold uppercase tracking-wider text-brass-100">
+                      {a.kind}
                     </span>
-                  )}
-                  {a.result && (
-                    <span className={`rounded px-1.5 py-0.5 uppercase ${
-                      a.result === 'win' ? 'bg-green-900/40 text-green-200'
-                      : a.result === 'loss' ? 'bg-red-900/40 text-red-200'
-                      : 'bg-yellow-900/40 text-yellow-200'
-                    }`}>
-                      {a.result}
-                    </span>
-                  )}
-                  {a.planet_name && (
-                    <Link href={`/map?planet=${a.planet_id}`} className="relative z-10 text-brass-300 hover:text-brass-100">
-                      ◈ {a.planet_name}
-                    </Link>
-                  )}
-                  {a.adversary_name && (
-                    <span>
-                      vs{' '}
-                      <Link
-                        href={a.adversary_user_id ? `/player/${a.adversary_user_id}` : '#'}
-                        className="relative z-10 text-brass-300 hover:text-brass-100"
-                      >
-                        {a.adversary_name}
+                    {a.game_system_short && (
+                      <span className="rounded border border-brass-700/40 px-1.5 py-0.5 uppercase">
+                        {a.game_system_short}
+                      </span>
+                    )}
+                    {a.result && (
+                      <span className={`rounded px-1.5 py-0.5 uppercase ${
+                        a.result === 'win' ? 'bg-green-900/40 text-green-200'
+                        : a.result === 'loss' ? 'bg-red-900/40 text-red-200'
+                        : 'bg-yellow-900/40 text-yellow-200'
+                      }`}>
+                        {a.result}
+                      </span>
+                    )}
+                    {a.planet_name && (
+                      <Link href={`/map?planet=${a.planet_id}`} className="text-brass-300 hover:text-brass-100">
+                        ◈ {a.planet_name}
                       </Link>
+                    )}
+                    {a.adversary_name && (
+                      <span>
+                        vs{' '}
+                        <Link
+                          href={a.adversary_user_id ? `/player/${a.adversary_user_id}` : '#'}
+                          className="text-brass-300 hover:text-brass-100"
+                        >
+                          {a.adversary_name}
+                        </Link>
+                      </span>
+                    )}
+                    <span className="ml-auto text-parchment-400">
+                      {new Date(a.created_at).toLocaleDateString()}
                     </span>
-                  )}
-                  <span className="ml-auto text-parchment-400">
-                    {new Date(a.created_at).toLocaleDateString()}
-                  </span>
+                  </div>
+                  {a.title && <p className="font-cinzel text-parchment-100 group-hover:text-brass-200 transition-colors">{a.title}</p>}
+                  {a.description && <p className="text-sm text-parchment-300">{a.description}</p>}
                 </div>
-                {a.title && <p className="mt-1 font-cinzel text-parchment-100 group-hover:text-brass-200 transition-colors">{a.title}</p>}
-                {a.description && <p className="mt-1 text-sm text-parchment-300">{a.description}</p>}
               </li>
             ))}
           </ul>

--- a/app/player/[id]/page.tsx
+++ b/app/player/[id]/page.tsx
@@ -209,9 +209,14 @@ export default async function PlayerProfilePage({ params }: PageProps) {
             {activityRows.map((a) => (
               <li
                 key={a.submission_id}
-                className="rounded border border-brass-700/40 bg-parchment-900/50 p-3"
+                className="group relative rounded border border-brass-700/40 bg-parchment-900/50 p-3 transition-colors hover:border-brass-500/60"
               >
-                <div className="flex flex-wrap items-center gap-2 text-xs text-parchment-300">
+                <Link
+                  href={`/submission/${a.submission_id}`}
+                  aria-label={`View deed: ${a.title ?? a.kind}`}
+                  className="absolute inset-0 z-0 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-brass focus-visible:ring-inset"
+                />
+                <div className="relative z-10 flex flex-wrap items-center gap-2 text-xs text-parchment-300">
                   <span className="rounded bg-brass-700/30 px-1.5 py-0.5 font-bold uppercase tracking-wider text-brass-100">
                     {a.kind}
                   </span>
@@ -230,7 +235,7 @@ export default async function PlayerProfilePage({ params }: PageProps) {
                     </span>
                   )}
                   {a.planet_name && (
-                    <Link href={`/map?planet=${a.planet_id}`} className="text-brass-300 hover:text-brass-100">
+                    <Link href={`/map?planet=${a.planet_id}`} className="relative z-10 text-brass-300 hover:text-brass-100">
                       ◈ {a.planet_name}
                     </Link>
                   )}
@@ -239,7 +244,7 @@ export default async function PlayerProfilePage({ params }: PageProps) {
                       vs{' '}
                       <Link
                         href={a.adversary_user_id ? `/player/${a.adversary_user_id}` : '#'}
-                        className="text-brass-300 hover:text-brass-100"
+                        className="relative z-10 text-brass-300 hover:text-brass-100"
                       >
                         {a.adversary_name}
                       </Link>
@@ -249,7 +254,7 @@ export default async function PlayerProfilePage({ params }: PageProps) {
                     {new Date(a.created_at).toLocaleDateString()}
                   </span>
                 </div>
-                {a.title && <p className="mt-1 font-cinzel text-parchment-100">{a.title}</p>}
+                {a.title && <p className="mt-1 font-cinzel text-parchment-100 group-hover:text-brass-200 transition-colors">{a.title}</p>}
                 {a.description && <p className="mt-1 text-sm text-parchment-300">{a.description}</p>}
               </li>
             ))}

--- a/components/ActivityFeed.tsx
+++ b/components/ActivityFeed.tsx
@@ -6,6 +6,7 @@
 
 import Link from 'next/link';
 import { createClient } from '@/lib/supabase/server';
+import KindBadge from '@/components/KindBadge';
 import type { ActivityFeedItem } from '@/lib/types';
 
 function timeAgo(iso: string): string {
@@ -23,21 +24,6 @@ function timeAgo(iso: string): string {
   if (mo  < 12)     return `${mo}mo ago`;
   const yr  = Math.floor(mo / 12);
   return `${yr}y ago`;
-}
-
-function KindBadge({ kind }: { kind: string }) {
-  const map: Record<string, { label: string; cls: string; icon: string }> = {
-    battle:  { label: 'Battle',  cls: 'border-red-700/60   bg-red-900/30   text-red-200',    icon: '⚔' },
-    painted: { label: 'Painted', cls: 'border-blue-700/60  bg-blue-900/30  text-blue-200',   icon: '🖌' },
-    lore:    { label: 'Lore',    cls: 'border-amber-700/60 bg-amber-900/30 text-amber-200',  icon: '📜' },
-    bonus:   { label: 'Bonus',   cls: 'border-purple-700/60 bg-purple-900/30 text-purple-200', icon: '✦' },
-  };
-  const cfg = map[kind] ?? { label: kind, cls: 'border-brass/40 bg-brass/20 text-brass-bright', icon: '✠' };
-  return (
-    <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${cfg.cls}`}>
-      <span aria-hidden>{cfg.icon}</span> {cfg.label}
-    </span>
-  );
 }
 
 function ResultBadge({ result }: { result: string | null }) {
@@ -89,22 +75,21 @@ export default async function ActivityFeed({ limit = 15 }: { limit?: number }) {
           key={it.submission_id}
           className="group relative flex flex-col gap-3 rounded border border-brass/20 bg-ink-2/60 p-4 transition-colors hover:border-brass/60 sm:flex-row"
         >
-          {/* Stretched overlay link — makes the whole card clickable.
-              Inner <Link> elements sit above this via relative z-10 so
-              they still get their own click targets (player profile,
-              planet page, adversary profile). The rounded + inset ring
-              appears on keyboard focus so tab-navigation is visible. */}
+          {/* Stretched overlay link — sits ABOVE the card content (z-10) so a
+              click anywhere on the card navigates to the submission detail.
+              Inner <Link> elements (avatar, name, planet, adversary) are
+              promoted to z-20 so they remain clickable on top of the overlay. */}
           <Link
             href={`/submission/${it.submission_id}`}
             aria-label={`View details: ${it.title ?? 'deed'}`}
-            className="absolute inset-0 z-0 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-brass focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
+            className="absolute inset-0 z-10 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-brass focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
           />
 
           {/* Avatar */}
-          <div className="relative z-10 flex shrink-0 items-start gap-3 sm:flex-col sm:items-center">
+          <div className="flex shrink-0 items-start gap-3 sm:flex-col sm:items-center">
             <Link
               href={it.user_id ? `/player/${it.user_id}` : '#'}
-              className="block h-12 w-12 shrink-0 overflow-hidden rounded-full border border-brass/50 bg-ink-2"
+              className="relative z-20 block h-12 w-12 shrink-0 overflow-hidden rounded-full border border-brass/50 bg-ink-2"
             >
               {it.avatar_url ? (
                 // Using <img> rather than next/image so external URLs don't need next.config.js tweaks.
@@ -118,12 +103,12 @@ export default async function ActivityFeed({ limit = 15 }: { limit?: number }) {
             </Link>
           </div>
 
-          <div className="relative z-10 flex min-w-0 flex-1 flex-col gap-2">
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
             {/* Header row */}
             <div className="flex flex-wrap items-center gap-2 text-sm">
               <Link
                 href={it.user_id ? `/player/${it.user_id}` : '#'}
-                className="font-display text-parchment hover:text-brass-bright transition-colors"
+                className="relative z-20 font-display text-parchment hover:text-brass-bright transition-colors"
               >
                 {it.display_name}
               </Link>
@@ -160,7 +145,7 @@ export default async function ActivityFeed({ limit = 15 }: { limit?: number }) {
               {it.planet_name && (
                 <span>
                   <span className="text-brass">◈</span>{' '}
-                  <Link href={`/map?planet=${it.planet_id}`} className="relative z-10 hover:text-brass-bright">
+                  <Link href={`/map?planet=${it.planet_id}`} className="relative z-20 hover:text-brass-bright">
                     {it.planet_name}
                   </Link>
                 </span>
@@ -170,7 +155,7 @@ export default async function ActivityFeed({ limit = 15 }: { limit?: number }) {
                   vs{' '}
                   <Link
                     href={it.adversary_user_id ? `/player/${it.adversary_user_id}` : '#'}
-                    className="relative z-10 text-parchment hover:text-brass-bright"
+                    className="relative z-20 text-parchment hover:text-brass-bright"
                   >
                     {it.adversary_name}
                   </Link>
@@ -196,7 +181,7 @@ export default async function ActivityFeed({ limit = 15 }: { limit?: number }) {
               avoids the "cropped midsection" effect on portrait model
               photos. Click the card to see the full uncropped image. */}
           {it.image_url && (
-            <div className="relative z-10 shrink-0 self-start overflow-hidden rounded border border-brass/30 sm:order-last">
+            <div className="shrink-0 self-start overflow-hidden rounded border border-brass/30 sm:order-last">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={it.image_url}

--- a/components/KindBadge.tsx
+++ b/components/KindBadge.tsx
@@ -1,0 +1,20 @@
+// Accepts either UI vocabulary (battle/painted) emitted by the activity_feed
+// view, or the raw DB enum (game/model) read from the submissions table.
+// See migration 0003_submission_kind_alignment.sql for the mapping.
+const ALIAS: Record<string, string> = { game: 'battle', model: 'painted' };
+
+export default function KindBadge({ kind }: { kind: string }) {
+  const normalized = ALIAS[kind] ?? kind;
+  const map: Record<string, { label: string; cls: string; icon: string }> = {
+    battle:  { label: 'Battle',  cls: 'border-red-700/60    bg-red-900/30    text-red-200',    icon: '⚔' },
+    painted: { label: 'Painted', cls: 'border-blue-700/60   bg-blue-900/30   text-blue-200',   icon: '🖌' },
+    lore:    { label: 'Lore',    cls: 'border-amber-700/60  bg-amber-900/30  text-amber-200',  icon: '📜' },
+    bonus:   { label: 'Bonus',   cls: 'border-purple-700/60 bg-purple-900/30 text-purple-200', icon: '✦' },
+  };
+  const cfg = map[normalized] ?? { label: normalized, cls: 'border-brass/40 bg-brass/20 text-brass-bright', icon: '✠' };
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${cfg.cls}`}>
+      <span aria-hidden>{cfg.icon}</span> {cfg.label}
+    </span>
+  );
+}


### PR DESCRIPTION
Closes #12

## Changes
Both the **dashboard** submissions list and the **public player profile** chronicle now use a stretched overlay link (same pattern as the activity feed) so clicking anywhere on a deed card navigates to `/submission/:id`.

- Inner links (planet → map, adversary → player profile) are promoted to `z-10` so they retain their own click targets.
- Cards get a subtle hover highlight to signal they're clickable.

## Files changed
- `app/dashboard/page.tsx`
- `app/player/[id]/page.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)