### PR TITLE
Fix #13: planet descriptions on map + click-to-pin

### DIFF
--- a/app/map/OrbitalMap.tsx
+++ b/app/map/OrbitalMap.tsx
@@ -17,7 +17,12 @@ interface Props {
 }
 
 export default function OrbitalMap({ planets, points, factions }: Props) {
+  // Two-state model: a hover overrides whatever is pinned, so moving the
+  // cursor to a new world swaps the panel immediately. A click pins the
+  // current planet so it survives mouse-leave; hovering a *different*
+  // world clears the pin (per spec). Clicking blank canvas also clears.
   const [hovered, setHovered] = useState<string | null>(null);
+  const [pinned, setPinned]   = useState<string | null>(null);
 
   const factionById = useMemo(() => {
     const m = new Map<string, MapFaction>();
@@ -36,13 +41,30 @@ export default function OrbitalMap({ planets, points, factions }: Props) {
     return m;
   }, [points]);
 
-  const hoveredPlanet = hovered ? planets.find((p) => p.id === hovered) : null;
-  const hoveredPoints = hovered ? pointsByPlanet.get(hovered) ?? [] : [];
+  const activeId = hovered ?? pinned;
+  const hoveredPlanet = activeId ? planets.find((p) => p.id === activeId) : null;
+  const hoveredPoints = activeId ? pointsByPlanet.get(activeId) ?? [] : [];
+
+  function enterPlanet(id: string) {
+    setHovered(id);
+    if (pinned && pinned !== id) setPinned(null);
+  }
+  function leavePlanet() {
+    setHovered(null);
+  }
+  function clickPlanet(id: string, e: React.MouseEvent) {
+    e.stopPropagation();
+    setPinned((prev) => (prev === id ? null : id));
+  }
 
   return (
     <div className="flex flex-col gap-4 lg:flex-row">
-      {/* Map canvas */}
-      <div className="relative w-full overflow-hidden rounded border border-brass-700/40 bg-[#0b0a14] lg:flex-[2]">
+      {/* Map canvas. Clicks on the canvas (outside any planet button)
+          clear the pinned selection — planet onClick stops propagation. */}
+      <div
+        onClick={() => setPinned(null)}
+        className="relative w-full overflow-hidden rounded border border-brass-700/40 bg-[#0b0a14] lg:flex-[2]"
+      >
         {/* Starfield background */}
         <div
           aria-hidden
@@ -68,23 +90,26 @@ export default function OrbitalMap({ planets, points, factions }: Props) {
             const controllingColor = p.controlling_faction_id
               ? factionById.get(p.controlling_faction_id)?.color ?? null
               : null;
-            const isHover = hovered === p.id;
+            const isActive = activeId === p.id;
+            const isPinned = pinned === p.id;
 
             return (
               <button
                 key={p.id}
                 type="button"
-                onMouseEnter={() => setHovered(p.id)}
-                onMouseLeave={() => setHovered(null)}
-                onFocus={() => setHovered(p.id)}
-                onBlur={() => setHovered(null)}
+                onMouseEnter={() => enterPlanet(p.id)}
+                onMouseLeave={leavePlanet}
+                onFocus={() => enterPlanet(p.id)}
+                onBlur={leavePlanet}
+                onClick={(e) => clickPlanet(p.id, e)}
                 className="group absolute -translate-x-1/2 -translate-y-1/2 transform"
                 style={{ left: `${x}%`, top: `${y}%` }}
                 aria-label={p.name}
+                aria-pressed={isPinned}
               >
                 {/* Control ring */}
                 <div
-                  className={`absolute inset-0 rounded-full transition-transform ${isHover ? 'scale-125' : 'scale-110'}`}
+                  className={`absolute inset-0 rounded-full transition-transform ${isActive ? 'scale-125' : 'scale-110'}`}
                   style={{
                     boxShadow: controllingColor
                       ? `0 0 0 2px ${controllingColor}, 0 0 24px ${controllingColor}66`
@@ -94,7 +119,7 @@ export default function OrbitalMap({ planets, points, factions }: Props) {
                 {/* Planet body */}
                 <div
                   className={`relative h-10 w-10 overflow-hidden rounded-full border border-brass-700/60 transition-transform sm:h-12 sm:w-12 ${
-                    isHover ? 'scale-110' : ''
+                    isActive ? 'scale-110' : ''
                   }`}
                   style={{
                     backgroundColor: controllingColor ?? '#2b2840',
@@ -147,6 +172,12 @@ export default function OrbitalMap({ planets, points, factions }: Props) {
                 </p>
               </div>
             </div>
+
+            {hoveredPlanet.description && (
+              <p className="mt-3 whitespace-pre-line font-body text-sm italic leading-relaxed text-parchment-dim">
+                {hoveredPlanet.description}
+              </p>
+            )}
 
             <h3 className="mt-4 font-cinzel text-sm uppercase tracking-wider text-brass-300">
               Contesting factions

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -17,6 +17,7 @@ export const revalidate = 30;
 export interface MapPlanet {
   id: string;
   name: string;
+  description: string | null;
   position_x: number | null;
   position_y: number | null;
   claim_threshold: number;
@@ -39,7 +40,7 @@ export interface MapFaction {
 export default async function MapPage() {
   const supabase = await createClient();
   const [pRes, ppRes, fRes] = await Promise.all([
-    supabase.from('planets').select('id, name, position_x, position_y, claim_threshold:threshold, image_url, controlling_faction_id'),
+    supabase.from('planets').select('id, name, description, position_x, position_y, claim_threshold:threshold, image_url, controlling_faction_id'),
     supabase.from('planet_points').select('planet_id, faction_id, points'),
     supabase.from('factions').select('id, name, color'),
   ]);


### PR DESCRIPTION
## Summary
- Show planet `description` (flavor text) in the map side panel when hovering or pinning a world.
- Add click-to-pin: a click on a planet keeps it shown in the panel; hovering a different planet replaces the pin; clicking blank canvas clears it.
- `aria-pressed` reflects pinned state for accessibility.

## Test plan
- [x] Visit `/map` on the preview build.
- [x] Hover a planet with a description → flavor text appears under the title block, above "Contesting factions".
- [x] Click a planet → it stays pinned after mouse-leave.
- [x] Hover a different planet while pinned → pin clears, new planet shown live.
- [x] Click empty space on the map canvas → pin clears, panel returns to default.
- [x] Tab to a planet button via keyboard → focus shows the planet; Enter pins it.
- [x] Planets without a description don't render an empty block.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)