### PR TITLE
Fix #11: configurable avatars + dashboard styling sweep

### DIFF
--- a/app/dashboard/DashboardProfile.tsx
+++ b/app/dashboard/DashboardProfile.tsx
@@ -3,18 +3,12 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
-import type { Faction, Profile } from "@/lib/types";
+import type { Profile } from "@/lib/types";
 
-export function DashboardProfile({
-  profile,
-  factions,
-}: {
-  profile: Profile;
-  factions: Faction[];
-}) {
+export function DashboardProfile({ profile }: { profile: Profile }) {
   const router = useRouter();
   const [displayName, setDisplayName] = useState(profile.display_name);
-  const [factionId, setFactionId] = useState(profile.faction_id ?? "");
+  const [avatarUrl, setAvatarUrl] = useState(profile.avatar_url ?? "");
   const [busy, setBusy] = useState(false);
   const [saved, setSaved] = useState(false);
 
@@ -22,9 +16,13 @@ export function DashboardProfile({
     e.preventDefault();
     setBusy(true); setSaved(false);
     const supabase = createClient();
+    const trimmed = avatarUrl.trim();
     const { error } = await supabase
       .from("profiles")
-      .update({ display_name: displayName, faction_id: factionId || null })
+      .update({
+        display_name: displayName,
+        avatar_url: trimmed || null,
+      })
       .eq("id", profile.id);
     setBusy(false);
     if (error) return alert(error.message);
@@ -33,32 +31,50 @@ export function DashboardProfile({
     router.refresh();
   }
 
+  const trimmedAvatar = avatarUrl.trim();
+
   return (
     <form onSubmit={save} className="card p-6">
       <div className="font-display uppercase tracking-widest text-xs text-brass mb-4">
-        Your Banner
+        Player Information
       </div>
-      <div className="grid md:grid-cols-2 gap-4">
-        <div>
-          <label className="label">Commander's Name</label>
-          <input
-            type="text" required value={displayName}
-            onChange={(e) => setDisplayName(e.target.value)}
-            className="input w-full"
-          />
+      <div className="flex items-start gap-4">
+        <div className="h-20 w-20 shrink-0 overflow-hidden rounded-full border border-brass/50 bg-ink-2">
+          {trimmedAvatar ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={trimmedAvatar}
+              alt={displayName || "Avatar"}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center font-display text-2xl text-brass">
+              {(displayName || "?").charAt(0).toUpperCase()}
+            </div>
+          )}
         </div>
-        <div>
-          <label className="label">Faction</label>
-          <select
-            value={factionId}
-            onChange={(e) => setFactionId(e.target.value)}
-            className="input w-full"
-          >
-            <option value="">— Unaligned —</option>
-            {factions.map((f) => (
-              <option key={f.id} value={f.id}>{f.name}</option>
-            ))}
-          </select>
+        <div className="flex-1 space-y-4">
+          <div>
+            <label className="label">Commander&apos;s Name</label>
+            <input
+              type="text" required value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              className="input w-full"
+            />
+          </div>
+          <div>
+            <label className="label">Avatar URL</label>
+            <input
+              type="url"
+              value={avatarUrl}
+              onChange={(e) => setAvatarUrl(e.target.value)}
+              placeholder="https://…"
+              className="input w-full"
+            />
+            <p className="mt-1 text-xs text-parchment-dim italic">
+              Discord sign-ins inherit your Discord avatar automatically. Paste any image URL to override.
+            </p>
+          </div>
         </div>
       </div>
       <div className="mt-4 flex items-center justify-end gap-3">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,6 +13,8 @@ import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import FactionMembership from '@/components/FactionMembership';
 import KindBadge from '@/components/KindBadge';
+import { DashboardProfile } from './DashboardProfile';
+import type { Profile } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 
@@ -44,7 +46,11 @@ export default async function DashboardPage() {
   if (!user) redirect('/auth/login?next=/dashboard');
 
   const [profileRes, eloRes, subsRes] = await Promise.all([
-    supabase.from('profiles').select('display_name').eq('id', user.id).maybeSingle(),
+    supabase
+      .from('profiles')
+      .select('id, display_name, faction_id, email, avatar_url, is_admin, created_at')
+      .eq('id', user.id)
+      .maybeSingle(),
     supabase
       .from('elo_ratings')
       .select('game_system_id, faction_id, rating, games_played, wins, losses, draws, factions(name, color), game_systems(short_name, name)')
@@ -58,33 +64,49 @@ export default async function DashboardPage() {
       .limit(25),
   ]);
 
-  const profile = profileRes.data as { display_name: string | null } | null;
+  const profile = (profileRes.data ?? null) as Profile | null;
   const elo  = (eloRes.data ?? []) as unknown as EloRow[];
   const subs = (subsRes.data ?? []) as unknown as SubRow[];
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-6 sm:px-6 sm:py-10">
       <header className="flex items-center gap-3">
-        <div className="h-14 w-14 overflow-hidden rounded-full border border-brass-700/50 bg-parchment-800">
-          <div className="flex h-full w-full items-center justify-center font-cinzel text-xl text-brass-300">
-            {(profile?.display_name ?? '?').charAt(0).toUpperCase()}
-          </div>
+        <div className="h-14 w-14 overflow-hidden rounded-full border border-brass/50 bg-ink-2">
+          {profile?.avatar_url ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={profile.avatar_url}
+              alt={profile.display_name ?? 'Avatar'}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center font-display text-xl text-brass">
+              {(profile?.display_name ?? '?').charAt(0).toUpperCase()}
+            </div>
+          )}
         </div>
         <div>
-          <p className="font-cinzel text-xs uppercase tracking-[0.3em] text-brass-300">
+          <p className="font-display text-xs uppercase tracking-[0.3em] text-brass">
             ✠ Your Dashboard ✠
           </p>
-          <h1 className="font-cinzel text-2xl text-brass-100 sm:text-3xl">
+          <h1 className="font-display text-2xl tracking-widest text-parchment sm:text-3xl">
             {profile?.display_name ?? 'Commander'}
           </h1>
         </div>
         <Link
           href={`/player/${user.id}`}
-          className="ml-auto rounded border border-brass-700/40 px-3 py-1.5 text-sm text-parchment-200 hover:text-brass-100"
+          className="ml-auto rounded border border-brass/40 px-3 py-1.5 text-sm text-parchment-dim transition-colors hover:border-brass hover:text-brass-bright"
         >
           View public profile →
         </Link>
       </header>
+
+      {/* Profile editor */}
+      {profile && (
+        <div className="mt-6">
+          <DashboardProfile profile={profile} />
+        </div>
+      )}
 
       {/* Faction memberships */}
       <div className="mt-6">
@@ -92,31 +114,33 @@ export default async function DashboardPage() {
       </div>
 
       {/* ELO */}
-      <section className="mt-6 rounded border border-brass-700/40 bg-parchment-900/40 p-4">
-        <h2 className="font-cinzel text-lg text-brass-100">Your Ratings</h2>
+      <section className="card p-6 mt-6">
+        <div className="font-display uppercase tracking-widest text-xs text-brass mb-2">
+          Your Ratings
+        </div>
         {elo.length === 0 ? (
-          <p className="mt-1 text-sm text-parchment-400">
+          <p className="text-sm text-parchment-dim italic">
             No rated games yet. Link an adversary when you submit a battle and both players earn ELO when approved.
           </p>
         ) : (
           <div className="mt-3 overflow-x-auto">
             <table className="w-full min-w-[500px] text-sm">
-              <thead className="text-left font-cinzel text-brass-200">
-                <tr>
-                  <th className="px-2 py-1">System</th>
-                  <th className="px-2 py-1">Faction</th>
-                  <th className="px-2 py-1 text-right">Rating</th>
-                  <th className="px-2 py-1 text-right">W</th>
-                  <th className="px-2 py-1 text-right">L</th>
-                  <th className="px-2 py-1 text-right">D</th>
+              <thead>
+                <tr className="border-b border-brass/20 text-xs font-display uppercase tracking-wider text-brass">
+                  <th className="text-left p-2">System</th>
+                  <th className="text-left p-2">Faction</th>
+                  <th className="text-right p-2">Rating</th>
+                  <th className="text-right p-2">W</th>
+                  <th className="text-right p-2">L</th>
+                  <th className="text-right p-2">D</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-brass-700/20">
+              <tbody>
                 {elo.map((r) => (
-                  <tr key={`${r.game_system_id}-${r.faction_id}`} className="text-parchment-200">
-                    <td className="px-2 py-1.5">{r.game_systems?.short_name ?? r.game_system_id}</td>
-                    <td className="px-2 py-1.5">
-                      <span className="inline-flex items-center gap-2">
+                  <tr key={`${r.game_system_id}-${r.faction_id}`} className="border-b border-brass/5">
+                    <td className="p-2 text-parchment">{r.game_systems?.short_name ?? r.game_system_id}</td>
+                    <td className="p-2">
+                      <span className="inline-flex items-center gap-2 text-parchment">
                         <span
                           className="inline-block h-2.5 w-2.5 rounded-full"
                           style={{ backgroundColor: r.factions?.color ?? '#7a5b20' }}
@@ -124,10 +148,10 @@ export default async function DashboardPage() {
                         {r.factions?.name ?? r.faction_id}
                       </span>
                     </td>
-                    <td className="px-2 py-1.5 text-right font-bold text-brass-100">{r.rating}</td>
-                    <td className="px-2 py-1.5 text-right text-green-300">{r.wins}</td>
-                    <td className="px-2 py-1.5 text-right text-red-300">{r.losses}</td>
-                    <td className="px-2 py-1.5 text-right text-yellow-300">{r.draws}</td>
+                    <td className="p-2 text-right font-display text-brass-bright">{r.rating}</td>
+                    <td className="p-2 text-right text-green-300">{r.wins}</td>
+                    <td className="p-2 text-right text-red-300">{r.losses}</td>
+                    <td className="p-2 text-right text-yellow-300">{r.draws}</td>
                   </tr>
                 ))}
               </tbody>
@@ -137,22 +161,24 @@ export default async function DashboardPage() {
       </section>
 
       {/* Submissions */}
-      <section className="mt-6 rounded border border-brass-700/40 bg-parchment-900/40 p-4">
-        <div className="flex items-center justify-between gap-2">
-          <h2 className="font-cinzel text-lg text-brass-100">Your Submissions</h2>
+      <section className="card p-6 mt-6">
+        <div className="flex items-center justify-between gap-2 mb-2">
+          <div className="font-display uppercase tracking-widest text-xs text-brass">
+            Your Submissions
+          </div>
           <Link
             href="/submit"
-            className="rounded border border-brass-500 bg-brass-700/30 px-2.5 py-1 text-xs font-cinzel text-brass-100 hover:bg-brass-600/40"
+            className="rounded border border-brass/60 bg-brass/20 px-2.5 py-1 text-xs font-display uppercase tracking-wider text-brass-bright transition-colors hover:bg-brass/30"
           >
             Submit a Deed
           </Link>
         </div>
         {subs.length === 0 ? (
-          <p className="mt-1 text-sm text-parchment-400">No submissions yet.</p>
+          <p className="text-sm text-parchment-dim italic">No submissions yet.</p>
         ) : (
-          <ul className="mt-3 flex flex-col divide-y divide-brass-700/20">
+          <ul className="mt-3 flex flex-col divide-y divide-brass/10">
             {subs.map((s) => (
-              <li key={s.id} className="group relative flex flex-wrap items-center gap-2 px-2 py-2 text-sm transition-colors hover:bg-brass/10">
+              <li key={s.id} className="group relative flex flex-wrap items-center gap-2 px-2 py-2 text-sm transition-colors hover:bg-brass/5">
                 {/* Stretched overlay sits on top so clicks anywhere on the row navigate.
                     No inner links exist here, so a single overlay is sufficient. */}
                 <Link
@@ -163,7 +189,7 @@ export default async function DashboardPage() {
                 <KindBadge kind={s.kind} />
                 <span className="text-parchment transition-colors group-hover:text-brass-bright">{s.title ?? '(untitled)'}</span>
                 {s.planets?.name && (
-                  <span className="text-parchment-400">· {s.planets.name}</span>
+                  <span className="text-parchment-dim">· {s.planets.name}</span>
                 )}
                 <span className={`ml-auto rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
                   s.status === 'approved' ? 'bg-green-900/40 text-green-200'
@@ -173,9 +199,9 @@ export default async function DashboardPage() {
                   {s.status}
                 </span>
                 {s.points !== null && (
-                  <span className="text-xs text-brass-300">+{s.points}</span>
+                  <span className="text-xs text-brass-bright">+{s.points}</span>
                 )}
-                <span className="w-full text-right text-[10px] text-parchment-400 sm:w-auto">
+                <span className="w-full text-right text-[10px] text-parchment-dark sm:w-auto">
                   {new Date(s.created_at).toLocaleDateString()}
                 </span>
               </li>

--- a/app/player/[id]/page.tsx
+++ b/app/player/[id]/page.tsx
@@ -21,6 +21,7 @@ interface ProfileRow {
   id: string;
   display_name: string | null;
   faction_id: string | null;
+  avatar_url: string | null;
   created_at: string;
 }
 
@@ -48,7 +49,7 @@ export default async function PlayerProfilePage({ params }: PageProps) {
 
   const { data: profile } = await supabase
     .from('profiles')
-    .select('id, display_name, faction_id, created_at')
+    .select('id, display_name, faction_id, avatar_url, created_at')
     .eq('id', id)
     .maybeSingle();
 
@@ -93,10 +94,19 @@ export default async function PlayerProfilePage({ params }: PageProps) {
     <main className="mx-auto max-w-6xl px-4 py-6 sm:px-6 sm:py-10">
       {/* Header */}
       <header className="flex flex-col items-start gap-4 rounded border border-brass-700/40 bg-parchment-900/50 p-4 sm:flex-row sm:items-center sm:p-6">
-        <div className="h-20 w-20 shrink-0 overflow-hidden rounded-full border border-brass-700/50 bg-parchment-800">
-          <div className="flex h-full w-full items-center justify-center font-cinzel text-2xl text-brass-300">
-            {(p.display_name ?? '?').charAt(0).toUpperCase()}
-          </div>
+        <div className="h-20 w-20 shrink-0 overflow-hidden rounded-full border border-brass/50 bg-ink-2">
+          {p.avatar_url ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={p.avatar_url}
+              alt={p.display_name ?? 'Avatar'}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center font-display text-2xl text-brass">
+              {(p.display_name ?? '?').charAt(0).toUpperCase()}
+            </div>
+          )}
         </div>
         <div className="flex-1">
           <h1 className="font-cinzel text-2xl text-brass-100 sm:text-3xl">

--- a/components/FactionMembership.tsx
+++ b/components/FactionMembership.tsx
@@ -104,16 +104,27 @@ export default function FactionMembership({ userId }: Props) {
     setBusy(null);
   }
 
-  if (loading) return <div className="text-sm text-parchment-400">Loading faction memberships…</div>;
+  if (loading) {
+    return (
+      <section className="card p-6">
+        <div className="font-display uppercase tracking-widest text-xs text-brass mb-2">
+          Faction Memberships
+        </div>
+        <p className="text-sm text-parchment-dim italic">Loading…</p>
+      </section>
+    );
+  }
 
   const joined = memberships
     .map((m) => ({ ...m, faction: allFactions.find((f) => f.id === m.faction_id) }))
     .filter((row) => row.faction);
 
   return (
-    <section className="rounded border border-brass-700/40 bg-parchment-900/40 p-4">
-      <h2 className="font-cinzel text-lg text-brass-100">Faction Memberships</h2>
-      <p className="mt-1 text-sm text-parchment-300">
+    <section className="card p-6">
+      <div className="font-display uppercase tracking-widest text-xs text-brass mb-2">
+        Faction Memberships
+      </div>
+      <p className="text-sm text-parchment-dim italic">
         You may pledge your banner to multiple factions. One is marked <em>primary</em> — it&apos;s the default
         when submitting deeds, and is used for leaderboard display.
       </p>
@@ -128,16 +139,16 @@ export default function FactionMembership({ userId }: Props) {
         {joined.map((row) => (
           <li
             key={row.faction_id}
-            className="flex flex-wrap items-center gap-2 rounded border border-brass-700/40 bg-parchment-950 px-3 py-2"
+            className="flex flex-wrap items-center gap-2 rounded border border-brass/30 bg-ink/60 px-3 py-2"
           >
             <span
               className="inline-block h-3 w-3 rounded-full"
               style={{ backgroundColor: row.faction?.color ?? '#7a5b20' }}
               aria-hidden
             />
-            <span className="font-cinzel text-parchment-100">{row.faction?.name}</span>
+            <span className="font-display text-parchment">{row.faction?.name}</span>
             {row.is_primary && (
-              <span className="rounded border border-brass-600 bg-brass-700/30 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-brass-100">
+              <span className="rounded border border-brass/60 bg-brass/20 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-brass-bright">
                 Primary
               </span>
             )}
@@ -147,7 +158,7 @@ export default function FactionMembership({ userId }: Props) {
                   type="button"
                   onClick={() => makePrimary(row.faction_id)}
                   disabled={busy === row.faction_id}
-                  className="rounded border border-brass-700/40 px-2 py-1 text-xs text-parchment-200 hover:text-brass-100 disabled:opacity-50"
+                  className="rounded border border-brass/40 px-2 py-1 text-xs text-parchment-dim hover:border-brass hover:text-brass-bright disabled:opacity-50"
                 >
                   Make primary
                 </button>
@@ -167,15 +178,15 @@ export default function FactionMembership({ userId }: Props) {
 
       {availableToJoin.length > 0 && (
         <div className="mt-4">
-          <label className="block text-sm text-parchment-200">Pledge to another faction</label>
-          <div className="mt-1 flex flex-wrap gap-2">
+          <span className="label">Pledge to another faction</span>
+          <div className="flex flex-wrap gap-2">
             {availableToJoin.map((f) => (
               <button
                 key={f.id}
                 type="button"
                 onClick={() => join(f.id)}
                 disabled={busy === f.id}
-                className="rounded border border-brass-700/40 bg-parchment-950 px-3 py-1.5 text-sm text-parchment-100 hover:border-brass-500 disabled:opacity-50"
+                className="rounded border border-brass/30 bg-ink/60 px-3 py-1.5 text-sm text-parchment hover:border-brass hover:text-brass-bright disabled:opacity-50"
               >
                 + {f.name}
               </button>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,6 +11,7 @@ export type Profile = {
   display_name: string;
   faction_id: string | null;
   email: string | null;
+  avatar_url: string | null;
   is_admin: boolean;
   created_at: string;
 };

--- a/supabase/migrations/0005_profiles_avatar_url.sql
+++ b/supabase/migrations/0005_profiles_avatar_url.sql
@@ -1,0 +1,114 @@
+-- ============================================================================
+-- 0005_profiles_avatar_url.sql
+--
+-- Issue #11: configurable user avatars.
+--   * Discord OAuth signups: capture `avatar_url` from raw_user_meta_data
+--     into profiles.avatar_url on first signup.
+--   * Anyone can override via the dashboard profile editor.
+--
+-- Storage: profiles.avatar_url (text, nullable). The activity_feed and
+-- searchable_players views already advertised `avatar_url` to the
+-- frontend but were returning placeholder `null::text`. They now expose
+-- profiles.avatar_url directly.
+-- ============================================================================
+
+-- 1. Column ------------------------------------------------------------------
+alter table public.profiles
+  add column if not exists avatar_url text;
+
+
+-- 2. handle_new_user — pull avatar_url from raw_user_meta_data on signup ----
+-- Discord OAuth puts the CDN URL at raw_user_meta_data.avatar_url.
+-- Email/password signups won't have one; the column simply stays null.
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+as $$
+begin
+  insert into public.profiles (id, display_name, email, avatar_url)
+  values (
+    new.id,
+    coalesce(new.raw_user_meta_data->>'display_name', split_part(new.email, '@', 1)),
+    new.email,
+    new.raw_user_meta_data->>'avatar_url'
+  );
+  return new;
+end;
+$$;
+
+
+-- 3. Backfill avatars for existing Discord users ----------------------------
+update public.profiles p
+set avatar_url = u.raw_user_meta_data->>'avatar_url'
+from auth.users u
+where u.id = p.id
+  and p.avatar_url is null
+  and u.raw_user_meta_data ? 'avatar_url';
+
+
+-- 4. Surface avatar_url through searchable_players --------------------------
+create or replace view public.searchable_players as
+select
+  p.id,
+  p.display_name,
+  p.avatar_url,
+  p.faction_id as primary_faction_id,
+  f.name       as primary_faction_name
+from public.profiles p
+left join public.factions f on f.id = p.faction_id
+where p.display_name is not null;
+
+grant select on public.searchable_players to anon, authenticated;
+
+
+-- 5. Surface avatar_url through activity_feed -------------------------------
+-- 0003 dropped + recreated this view because of a column type change. Here
+-- we're swapping `null::text` for `p.avatar_url` (also text), so CREATE OR
+-- REPLACE would suffice — but we follow the same drop-and-recreate pattern
+-- 0003 used to keep the migration trail consistent.
+drop view if exists public.activity_feed;
+
+create view public.activity_feed as
+select
+  s.id                              as submission_id,
+  case s.type
+    when 'game'  then 'battle'
+    when 'model' then 'painted'
+    else s.type::text
+  end::text                         as kind,
+  s.status,
+  s.created_at,
+  s.title,
+  s.body                            as description,
+  s.image_url,
+  s.points,
+  s.result,
+  s.game_size,
+  p.id                              as user_id,
+  coalesce(p.display_name, 'Unknown Commander') as display_name,
+  p.avatar_url                      as avatar_url,
+  f.id                              as faction_id,
+  f.name                            as faction_name,
+  f.color                           as faction_color,
+  pl.id                             as planet_id,
+  pl.name                           as planet_name,
+  gs.id                             as game_system_id,
+  gs.short_name                     as game_system_short,
+  gs.name                           as game_system_name,
+  adv.id                            as adversary_user_id,
+  coalesce(adv.display_name, s.opponent_name) as adversary_name,
+  advf.name                         as adversary_faction_name,
+  advf.color                        as adversary_faction_color,
+  vgt.name                          as video_game_name
+from public.submissions s
+left join public.profiles    p    on p.id = s.player_id
+left join public.factions    f    on f.id = s.faction_id
+left join public.planets     pl   on pl.id = s.target_planet_id
+left join public.game_systems gs  on gs.id = s.game_system_id
+left join public.profiles    adv  on adv.id = s.adversary_user_id
+left join public.factions    advf on advf.id = s.adversary_faction_id
+left join public.video_game_titles vgt on vgt.id = s.video_game_title_id
+where s.status = 'approved';
+
+grant select on public.activity_feed to anon, authenticated;


### PR DESCRIPTION
## Summary
- Adds `profiles.avatar_url` (migration `0005_profiles_avatar_url.sql`). `handle_new_user` now captures `raw_user_meta_data->>'avatar_url'` on signup, so Discord OAuth users inherit their Discord avatar automatically. A backfill UPDATE applies the same to existing Discord users.
- Surfaces `avatar_url` through the `activity_feed` and `searchable_players` views (they previously returned `null::text` placeholders even though the frontend already read the field).
- Wires up the orphaned `DashboardProfile` editor as a "Player Information" card with avatar URL field + live preview circle. Faction selector removed — `FactionMembership` already covers that.
- Restyles `FactionMembership`, "Your Ratings", "Your Submissions", and the dashboard header to use the project's brass/parchment/ink theme tokens. The previous `brass-700`/`parchment-XXX`/`font-cinzel` classes weren't defined in `tailwind.config.js`, so they rendered with no styling.
- Public player profile (`/player/[id]`) header now shows the avatar.

## Test plan
- [x] Run `0005_profiles_avatar_url.sql` in Supabase SQL editor.
- [x] `/dashboard`: header avatar pulls from `profiles.avatar_url`, falling back to the initial-letter circle when null.
- [x] **Player Information** card has only Commander's Name + Avatar URL (no faction selector). Live preview updates as the URL is typed.
- [x] Save persists across refresh; clearing the URL falls back to the initial circle everywhere.
- [x] **Faction Memberships**, **Your Ratings**, **Your Submissions** all sit in `card p-6` containers with brass uppercase headings and consistent brass/parchment color usage.
- [x] `/player/<your-uuid>`: avatar shown in header.
- [x] Activity feed (`/`): cards now show real avatars where users have one set.
- [x] AdversaryPicker on `/submit`: typeahead results display avatars.
- [x] Submit a fresh deed and the avatar appears on the activity feed item.
- [x] Existing Discord OAuth user's avatar populates after the migration runs (backfill verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)