### PR TITLE
Fix #4: planet game-system allowlist + faction edit in admin UI

### DIFF
--- a/app/admin/AdminFactions.tsx
+++ b/app/admin/AdminFactions.tsx
@@ -12,6 +12,11 @@ export function AdminFactions({ factions }: { factions: Faction[] }) {
   const [color, setColor] = useState("#b8892d");
   const [busy, setBusy] = useState(false);
 
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editColor, setEditColor] = useState("#b8892d");
+  const [savingEdit, setSavingEdit] = useState(false);
+
   async function createFaction(e: React.FormEvent) {
     e.preventDefault();
     setBusy(true);
@@ -29,6 +34,29 @@ export function AdminFactions({ factions }: { factions: Faction[] }) {
     const supabase = createClient();
     const { error } = await supabase.from("factions").delete().eq("id", id);
     if (error) return alert(error.message);
+    router.refresh();
+  }
+
+  function startEdit(f: Faction) {
+    setEditingId(f.id);
+    setEditName(f.name);
+    setEditColor(f.color);
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+  }
+
+  async function saveEdit(id: string) {
+    setSavingEdit(true);
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("factions")
+      .update({ name: editName, color: editColor })
+      .eq("id", id);
+    setSavingEdit(false);
+    if (error) return alert(error.message);
+    setEditingId(null);
     router.refresh();
   }
 
@@ -69,18 +97,66 @@ export function AdminFactions({ factions }: { factions: Faction[] }) {
       )}
 
       <div className="grid md:grid-cols-2 gap-3">
-        {factions.map((f) => (
-          <div key={f.id} className="card p-3 flex items-center gap-3">
-            <div className="w-8 h-8 rounded-sm" style={{ backgroundColor: f.color }} />
-            <div className="flex-1 font-display text-parchment">{f.name}</div>
-            <button
-              onClick={() => deleteFaction(f.id)}
-              className="btn-danger text-xs"
-            >
-              Delete
-            </button>
-          </div>
-        ))}
+        {factions.map((f) => {
+          const isEditing = editingId === f.id;
+          return (
+            <div key={f.id} className="card p-3">
+              {isEditing ? (
+                <div className="space-y-3">
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="color"
+                      value={editColor}
+                      onChange={(e) => setEditColor(e.target.value)}
+                      className="input w-12 h-10 p-1 shrink-0"
+                      aria-label="Banner color"
+                    />
+                    <input
+                      type="text"
+                      value={editName}
+                      onChange={(e) => setEditName(e.target.value)}
+                      className="input flex-1"
+                      placeholder="Faction name"
+                    />
+                  </div>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={cancelEdit}
+                      disabled={savingEdit}
+                      className="btn-ghost text-xs"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => saveEdit(f.id)}
+                      disabled={savingEdit || !editName.trim()}
+                      className="btn-primary text-xs disabled:opacity-50"
+                    >
+                      {savingEdit ? "Saving…" : "Save"}
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-sm shrink-0" style={{ backgroundColor: f.color }} />
+                  <div className="flex-1 font-display text-parchment">{f.name}</div>
+                  <button
+                    onClick={() => startEdit(f)}
+                    className="btn-ghost text-xs"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => deleteFaction(f.id)}
+                    className="btn-danger text-xs"
+                  >
+                    Delete
+                  </button>
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/app/admin/AdminPlanets.tsx
+++ b/app/admin/AdminPlanets.tsx
@@ -1,16 +1,26 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
-import type { Planet, Faction } from "@/lib/types";
+import type {
+  Planet,
+  Faction,
+  GameSystem,
+  GameSystemId,
+  PlanetGameSystem,
+} from "@/lib/types";
 
 export function AdminPlanets({
   planets,
   factions,
+  gameSystems,
+  planetSystems,
 }: {
   planets: Planet[];
   factions: Faction[];
+  gameSystems: GameSystem[];
+  planetSystems: PlanetGameSystem[];
 }) {
   const router = useRouter();
   const [showNew, setShowNew] = useState(false);
@@ -22,6 +32,77 @@ export function AdminPlanets({
   const [threshold, setThreshold] = useState(100);
   const [x, setX] = useState(0.5);
   const [y, setY] = useState(0.5);
+
+  const initialAllowed = useMemo(() => {
+    const map = new Map<string, Set<GameSystemId>>();
+    for (const row of planetSystems) {
+      const set = map.get(row.planet_id) ?? new Set<GameSystemId>();
+      set.add(row.game_system_id);
+      map.set(row.planet_id, set);
+    }
+    return map;
+  }, [planetSystems]);
+
+  const [allowedByPlanet, setAllowedByPlanet] = useState<
+    Map<string, Set<GameSystemId>>
+  >(() => new Map(initialAllowed));
+  const [savingSystemsFor, setSavingSystemsFor] = useState<string | null>(null);
+
+  function getAllowed(planetId: string): Set<GameSystemId> {
+    return allowedByPlanet.get(planetId) ?? initialAllowed.get(planetId) ?? new Set();
+  }
+
+  function isDirty(planetId: string): boolean {
+    const current = allowedByPlanet.get(planetId);
+    if (!current) return false;
+    const original = initialAllowed.get(planetId) ?? new Set<GameSystemId>();
+    if (current.size !== original.size) return true;
+    for (const id of current) if (!original.has(id)) return true;
+    return false;
+  }
+
+  function toggleSystem(planetId: string, systemId: GameSystemId) {
+    setAllowedByPlanet((prev) => {
+      const next = new Map(prev);
+      const current = new Set(next.get(planetId) ?? initialAllowed.get(planetId) ?? []);
+      if (current.has(systemId)) current.delete(systemId);
+      else current.add(systemId);
+      next.set(planetId, current);
+      return next;
+    });
+  }
+
+  async function saveSystems(planetId: string) {
+    setSavingSystemsFor(planetId);
+    const supabase = createClient();
+    const allowed = getAllowed(planetId);
+
+    const { error: dErr } = await supabase
+      .from("planet_game_systems")
+      .delete()
+      .eq("planet_id", planetId);
+    if (dErr) {
+      setSavingSystemsFor(null);
+      return alert(dErr.message);
+    }
+
+    if (allowed.size > 0) {
+      const rows = Array.from(allowed).map((gsId) => ({
+        planet_id: planetId,
+        game_system_id: gsId,
+      }));
+      const { error: iErr } = await supabase
+        .from("planet_game_systems")
+        .insert(rows);
+      if (iErr) {
+        setSavingSystemsFor(null);
+        return alert(iErr.message);
+      }
+    }
+
+    setSavingSystemsFor(null);
+    router.refresh();
+  }
 
   async function createPlanet(e: React.FormEvent) {
     e.preventDefault();
@@ -123,29 +204,72 @@ export function AdminPlanets({
 
       <div className="space-y-3">
         {planets.map((p) => {
-          const controller = factions.find((f) => f.id === p.controlling_faction_id);
+          const allowed = getAllowed(p.id);
+          const dirty = isDirty(p.id);
+          const saving = savingSystemsFor === p.id;
           return (
-            <div key={p.id} className="card p-4 flex flex-wrap items-center gap-4">
-              <div className="flex-1 min-w-[200px]">
-                <div className="font-display text-parchment">{p.name}</div>
-                <div className="text-xs text-parchment-dark">
-                  threshold {p.threshold} · position ({p.position_x.toFixed(2)}, {p.position_y.toFixed(2)})
+            <div key={p.id} className="card p-4 space-y-3">
+              <div className="flex flex-wrap items-center gap-4">
+                <div className="flex-1 min-w-[200px]">
+                  <div className="font-display text-parchment">{p.name}</div>
+                  <div className="text-xs text-parchment-dark">
+                    threshold {p.threshold} · position ({p.position_x.toFixed(2)}, {p.position_y.toFixed(2)})
+                  </div>
+                </div>
+                <select
+                  value={p.controlling_faction_id ?? ""}
+                  onChange={(e) => setController(p.id, e.target.value || null)}
+                  className="input bg-ink text-parchment"
+                >
+                  <option value="" className="bg-ink text-parchment">— Contested —</option>
+                  {factions.map((f) => (
+                    <option key={f.id} value={f.id} className="bg-ink text-parchment">{f.name}</option>
+                  ))}
+                </select>
+                <button onClick={() => deletePlanet(p.id)} className="btn-danger text-xs">
+                  Delete
+                </button>
+              </div>
+
+              <div className="border-t border-brass/20 pt-3">
+                <div className="flex items-center justify-between gap-3 mb-2">
+                  <div>
+                    <div className="label !mb-0">Allowed game systems</div>
+                    <div className="text-xs text-parchment-dark italic">
+                      {allowed.size === 0
+                        ? "No restrictions — every system allowed."
+                        : `${allowed.size} system${allowed.size === 1 ? "" : "s"} allowed`}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => saveSystems(p.id)}
+                    disabled={!dirty || saving}
+                    className="btn-ghost text-xs disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    {saving ? "Saving…" : "Save"}
+                  </button>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {gameSystems.map((s) => {
+                    const active = allowed.has(s.id);
+                    return (
+                      <button
+                        key={s.id}
+                        type="button"
+                        onClick={() => toggleSystem(p.id, s.id)}
+                        className={`rounded border px-3 py-1.5 text-sm transition-colors ${
+                          active
+                            ? "border-brass bg-brass/10 text-parchment"
+                            : "border-brass/20 text-parchment-dim hover:border-brass/50"
+                        }`}
+                      >
+                        {s.short_name || s.name}
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
-              <select
-                value={p.controlling_faction_id ?? ""}
-                onChange={(e) => setController(p.id, e.target.value || null)}
-                className="input"
-                style={controller ? { color: controller.color } : {}}
-              >
-                <option value="">— Contested —</option>
-                {factions.map((f) => (
-                  <option key={f.id} value={f.id}>{f.name}</option>
-                ))}
-              </select>
-              <button onClick={() => deletePlanet(p.id)} className="btn-danger text-xs">
-                Delete
-              </button>
             </div>
           );
         })}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -3,7 +3,14 @@ import { createClient } from "@/lib/supabase/server";
 import { AdminQueue } from "./AdminQueue";
 import { AdminPlanets } from "./AdminPlanets";
 import { AdminFactions } from "./AdminFactions";
-import type { Submission, Faction, Planet, Profile } from "@/lib/types";
+import type {
+  Submission,
+  Faction,
+  Planet,
+  Profile,
+  GameSystem,
+  PlanetGameSystem,
+} from "@/lib/types";
 
 export const dynamic = "force-dynamic";
 
@@ -33,6 +40,8 @@ export default async function AdminPage() {
     { data: pending },
     { data: planets },
     { data: factions },
+    { data: gameSystems },
+    { data: planetSystems },
   ] = await Promise.all([
     supabase
       .from("submissions")
@@ -41,6 +50,8 @@ export default async function AdminPage() {
       .order("created_at", { ascending: true }),
     supabase.from("planets").select("*").order("name"),
     supabase.from("factions").select("*").order("name"),
+    supabase.from("game_systems").select("*").order("sort_order"),
+    supabase.from("planet_game_systems").select("planet_id, game_system_id"),
   ]);
 
   return (
@@ -76,6 +87,8 @@ export default async function AdminPage() {
         <AdminPlanets
           planets={(planets ?? []) as Planet[]}
           factions={(factions ?? []) as Faction[]}
+          gameSystems={(gameSystems ?? []) as GameSystem[]}
+          planetSystems={(planetSystems ?? []) as PlanetGameSystem[]}
         />
       </section>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,6 +7,7 @@
     background-color: #0a0806;
     color: #e8dcc0;
     font-family: "Cormorant Garamond", serif;
+    color-scheme: dark;
   }
 
   body {


### PR DESCRIPTION
## Summary

Closes #4.

- Surfaces the existing `planet_game_systems` allowlist as inline toggle buttons under each planet in `/admin` (no rows = unrestricted, matching the read path in `BattleSubmitForm`).
- Adds an Edit button to each faction row in `/admin` for renaming + recolouring banner colour without DB access.
- Adds `color-scheme: dark` on `<html>` so native form widgets (select chevron + dropdown panel, number-input spinners) render against the dark theme rather than light system defaults.

## Test plan

Pre-reqs: signed in as an admin (profile.is_admin = true) at `/admin`.

### Faction edit
- [x] In the FACTIONS section, click **Edit** on any faction. Row swaps to inline name + colour inputs.
- [x] Change the name and colour, click **Save**. Page refreshes and the row shows the new name + swatch.
- [x] Click **Edit** then **Cancel** — no change persists.
- [x] Clear the name field — the **Save** button is disabled.

### Planet game-system allowlist
- [x] In the WORLDS section, each planet row shows an "Allowed game systems" strip with one toggle per system.
- [x] On a planet with no rows in `planet_game_systems`, the strip shows all toggles inactive and the caption reads "No restrictions — every system allowed."
- [x] Click toggles to activate/deactivate; the **Save** button enables only when there are unsaved changes.
- [x] Click **Save**. The caption updates to "N system(s) allowed" matching the active toggles.
- [x] In another tab, go to `/submit` → Submit Battle. The Game System dropdown for the saved planet only includes the systems you allowed. (Empty allowlist still allows everything.)
- [x] Toggle every system off again, save — restrictions clear and all systems are allowed at submit.

### Native widget styling
- [x] In the WORLDS section, the controlling-faction `<select>` chevron + open dropdown panel are dark, matching `/submit`'s selects.
- [x] In the APPROVAL QUEUE, the **Adjust Points** number-input up/down spinner arrows render dark, not as light system defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)