### PR TITLE
Add #31: Lore Keeper submission type (split scribe + loremaster)

### DIFF
--- a/app/admin/AdminQueue.tsx
+++ b/app/admin/AdminQueue.tsx
@@ -91,6 +91,17 @@ export function AdminQueue({
                       {s.result}
                     </span>
                   )}
+                  {s.type === "loremaster" && s.lore_format && (
+                    <span className="inline-flex items-center gap-1 rounded-full border border-indigo-700/60 bg-indigo-900/30 px-2 py-0.5 text-xs font-medium text-indigo-200">
+                      <span aria-hidden>{s.lore_format === "novel" ? "📕" : "🎧"}</span>
+                      {s.lore_format === "novel" ? "Novel" : "Audiobook"}
+                    </span>
+                  )}
+                  {s.type === "loremaster" && s.lore_rating !== null && (
+                    <span className="text-sm text-brass-bright" aria-label={`${s.lore_rating} out of 5`}>
+                      {Array.from({ length: 5 }).map((_, i) => (i < (s.lore_rating ?? 0) ? "★" : "☆")).join("")}
+                    </span>
+                  )}
                 </div>
                 <h3 className="font-display text-xl text-parchment">{s.title}</h3>
                 <div className="mt-1 text-sm text-parchment-dim font-body">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -48,20 +48,22 @@ interface SubRow {
 const CATEGORY_ORDER: AwardCategory[] = ['combat', 'painting', 'lore', 'conquest', 'cross'];
 
 // Count-based awards: key -> target count and which counter feeds it.
-const PROGRESS_TARGETS: Record<string, { target: number; counter: 'game' | 'model' | 'lore' | 'distinct_types' }> = {
-  first_blood:            { target: 1,  counter: 'game' },
-  veteran:                { target: 3,  counter: 'game' },
-  honored_of_the_chapter: { target: 10, counter: 'game' },
-  warmaster:              { target: 20, counter: 'game' },
-  brush_initiate:         { target: 1,  counter: 'model' },
-  production_painter:     { target: 3,  counter: 'model' },
-  master_artisan:         { target: 10, counter: 'model' },
-  painting_daemon:        { target: 20, counter: 'model' },
-  remembrancer:           { target: 1,  counter: 'lore' },
-  chronicler:             { target: 3,  counter: 'lore' },
-  loremaster:             { target: 10, counter: 'lore' },
-  keeper_of_secrets:      { target: 20, counter: 'lore' },
-  accept_any_challenge:   { target: 4,  counter: 'distinct_types' },
+const PROGRESS_TARGETS: Record<string, { target: number; counter: 'game' | 'model' | 'scribe' | 'loremaster' | 'distinct_types' }> = {
+  first_blood:                 { target: 1,   counter: 'game' },
+  veteran:                     { target: 3,   counter: 'game' },
+  honored_of_the_chapter:      { target: 10,  counter: 'game' },
+  warmaster:                   { target: 20,  counter: 'game' },
+  brush_initiate:              { target: 1,   counter: 'model' },
+  production_painter:          { target: 3,   counter: 'model' },
+  master_artisan:              { target: 10,  counter: 'model' },
+  painting_daemon:             { target: 20,  counter: 'model' },
+  remembrancer:                { target: 1,   counter: 'scribe' },
+  chronicler:                  { target: 3,   counter: 'scribe' },
+  master_scribe:               { target: 10,  counter: 'scribe' },
+  keeper_of_secrets:           { target: 20,  counter: 'scribe' },
+  witness_of_the_word:         { target: 15,  counter: 'loremaster' },
+  keeper_of_the_black_library: { target: 100, counter: 'loremaster' },
+  accept_any_challenge:        { target: 4,   counter: 'distinct_types' },
 };
 
 export default async function DashboardPage() {
@@ -69,7 +71,7 @@ export default async function DashboardPage() {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect('/auth/login?next=/dashboard');
 
-  const [profileRes, eloRes, subsRes, awardsRes, playerAwardsRes, gameCountRes, modelCountRes, loreCountRes, bonusCountRes] = await Promise.all([
+  const [profileRes, eloRes, subsRes, awardsRes, playerAwardsRes, gameCountRes, modelCountRes, scribeCountRes, loremasterCountRes] = await Promise.all([
     supabase
       .from('profiles')
       .select('id, display_name, faction_id, email, avatar_url, is_admin, created_at')
@@ -105,11 +107,11 @@ export default async function DashboardPage() {
     supabase
       .from('submissions')
       .select('id', { count: 'exact', head: true })
-      .eq('player_id', user.id).eq('type', 'lore').eq('status', 'approved'),
+      .eq('player_id', user.id).eq('type', 'scribe').eq('status', 'approved'),
     supabase
       .from('submissions')
       .select('id', { count: 'exact', head: true })
-      .eq('player_id', user.id).eq('type', 'bonus').eq('status', 'approved'),
+      .eq('player_id', user.id).eq('type', 'loremaster').eq('status', 'approved'),
   ]);
 
   const profile = (profileRes.data ?? null) as Profile | null;
@@ -118,13 +120,14 @@ export default async function DashboardPage() {
   const awards = (awardsRes.data ?? []) as Award[];
   const playerAwards = (playerAwardsRes.data ?? []) as PlayerAward[];
 
-  const gameCount  = gameCountRes.count  ?? 0;
-  const modelCount = modelCountRes.count ?? 0;
-  const loreCount  = loreCountRes.count  ?? 0;
-  const bonusCount = bonusCountRes.count ?? 0;
-  const distinctTypes = [gameCount, modelCount, loreCount, bonusCount].filter((n) => n > 0).length;
+  const gameCount       = gameCountRes.count       ?? 0;
+  const modelCount      = modelCountRes.count      ?? 0;
+  const scribeCount     = scribeCountRes.count     ?? 0;
+  const loremasterCount = loremasterCountRes.count ?? 0;
+  // Bonus is admin-only and excluded from Accept Any Challenge.
+  const distinctTypes = [gameCount, modelCount, scribeCount, loremasterCount].filter((n) => n > 0).length;
 
-  const counters = { game: gameCount, model: modelCount, lore: loreCount, distinct_types: distinctTypes };
+  const counters = { game: gameCount, model: modelCount, scribe: scribeCount, loremaster: loremasterCount, distinct_types: distinctTypes };
   const earnedById = new Map(playerAwards.map((pa) => [pa.award_id, pa]));
 
   const featured: FeaturedAward[] = playerAwards

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -117,6 +117,7 @@ export default async function LeaderboardPage({ searchParams }: PageProps) {
                 <th className="text-right p-3 hidden sm:table-cell">Wins</th>
                 <th className="text-right p-3 hidden md:table-cell">Painted Units</th>
                 <th className="text-right p-3 hidden md:table-cell">Tales</th>
+                <th className="text-right p-3 hidden md:table-cell">Lore Read</th>
                 <th className="text-right p-3 hidden sm:table-cell">Worlds</th>
                 <th className="text-right p-3">Glory</th>
               </tr>
@@ -151,7 +152,8 @@ export default async function LeaderboardPage({ searchParams }: PageProps) {
                     </td>
                     <td className="p-3 text-right font-body hidden sm:table-cell">{f.wins}</td>
                     <td className="p-3 text-right font-body hidden md:table-cell">{f.models_painted}</td>
-                    <td className="p-3 text-right font-body hidden md:table-cell">{f.lore_submitted}</td>
+                    <td className="p-3 text-right font-body hidden md:table-cell">{f.lore_written}</td>
+                    <td className="p-3 text-right font-body hidden md:table-cell">{f.lore_read}</td>
                     <td className="p-3 text-right font-body hidden sm:table-cell">{f.planets_controlled}</td>
                     <td className="p-3 text-right font-display text-brass-bright">{f.total_points}</td>
                   </tr>

--- a/app/submission/[id]/page.tsx
+++ b/app/submission/[id]/page.tsx
@@ -26,10 +26,16 @@ function formatDate(iso: string): string {
 }
 
 const KIND_LABELS: Record<string, { label: string; icon: string }> = {
-  battle:  { label: 'Battle Report', icon: '⚔' },
-  painted: { label: 'Painted',       icon: '🖌' },
-  lore:    { label: 'Lore',          icon: '📜' },
-  bonus:   { label: 'Bonus',         icon: '✦' },
+  battle:     { label: 'Battle Report', icon: '⚔' },
+  painted:    { label: 'Painted',       icon: '🖌' },
+  scribe:     { label: 'Scribe',        icon: '📜' },
+  loremaster: { label: 'Loremaster',    icon: '📖' },
+  bonus:      { label: 'Bonus',         icon: '✦' },
+};
+
+const LORE_FORMAT_LABELS: Record<string, { label: string; icon: string }> = {
+  novel:     { label: 'Novel',     icon: '📕' },
+  audiobook: { label: 'Audiobook', icon: '🎧' },
 };
 
 export default async function SubmissionDetailPage({ params }: PageProps) {
@@ -110,6 +116,25 @@ export default async function SubmissionDetailPage({ params }: PageProps) {
             <span className="font-display text-parchment">{it.display_name}</span>
           )}
         </div>
+
+        {/* Loremaster format + rating */}
+        {it.kind === 'loremaster' && (it.lore_format || it.lore_rating) && (
+          <div className="mt-4 flex flex-wrap items-center gap-3 text-sm">
+            {it.lore_format && LORE_FORMAT_LABELS[it.lore_format] && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-indigo-700/60 bg-indigo-900/30 px-2 py-0.5 text-xs font-medium text-indigo-200">
+                <span aria-hidden>{LORE_FORMAT_LABELS[it.lore_format].icon}</span>
+                {LORE_FORMAT_LABELS[it.lore_format].label}
+              </span>
+            )}
+            {it.lore_rating !== null && it.lore_rating !== undefined && (
+              <span className="inline-flex items-center gap-0.5 text-brass-bright" aria-label={`${it.lore_rating} out of 5`}>
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <span key={i}>{i < (it.lore_rating ?? 0) ? '★' : '☆'}</span>
+                ))}
+              </span>
+            )}
+          </div>
+        )}
 
         {/* Full-size image — object-contain so nothing gets cropped. */}
         {it.image_url && (

--- a/app/submit/SubmitPageClient.tsx
+++ b/app/submit/SubmitPageClient.tsx
@@ -3,7 +3,9 @@
 // =====================================================================
 // app/submit/SubmitPageClient.tsx
 // Client wrapper: kind-picker tabs + per-kind forms. Battle uses the
-// rich BattleSubmitForm. Painted/Lore use a simple shared form.
+// rich BattleSubmitForm; loremaster (reading/listening) has its own
+// dedicated form because it captures format/rating/reflection. Painted
+// and Scribe (writing) share the simple form.
 // =====================================================================
 
 import { useMemo, useState } from 'react';
@@ -12,12 +14,12 @@ import { createClient } from '@/lib/supabase/client';
 import { uploadImage } from '@/lib/upload-image';
 import BattleSubmitForm from '@/components/BattleSubmitForm';
 import { POINT_PRESETS } from '@/lib/types';
-import type { GameSystemId } from '@/lib/types';
+import type { GameSystemId, LoreFormat } from '@/lib/types';
 
 interface Planet  { id: string; name: string; }
 interface Faction { id: string; name: string; }
 
-type Kind = 'battle' | 'painted' | 'lore';
+type Kind = 'battle' | 'painted' | 'scribe' | 'loremaster';
 
 interface Props {
   planets: Planet[];
@@ -27,9 +29,10 @@ interface Props {
 }
 
 const KINDS: Array<{ id: Kind; label: string; icon: string; desc: string }> = [
-  { id: 'battle',  label: 'Battle Report', icon: '⚔', desc: 'Log a game and claim glory on a world.' },
-  { id: 'painted', label: 'Painted Unit', icon: '🖌', desc: 'Share miniatures you finished painting.' },
-  { id: 'lore',    label: 'Lore',          icon: '📜', desc: 'Write a piece of campaign fiction.' },
+  { id: 'battle',     label: 'Battle Report', icon: '⚔', desc: 'Log a game and claim glory on a world.' },
+  { id: 'painted',    label: 'Painted Unit',  icon: '🖌', desc: 'Share miniatures you finished painting.' },
+  { id: 'scribe',     label: 'Scribe',        icon: '📜', desc: 'Write a piece of campaign fiction.' },
+  { id: 'loremaster', label: 'Loremaster',    icon: '📖', desc: 'Log a novel or audio drama you read.' },
 ];
 
 export default function SubmitPageClient({ planets, userFactions, planetSystems, currentUserId }: Props) {
@@ -38,7 +41,7 @@ export default function SubmitPageClient({ planets, userFactions, planetSystems,
   return (
     <div>
       {/* Kind selector */}
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
         {KINDS.map((k) => {
           const active = kind === k.id;
           return (
@@ -70,6 +73,12 @@ export default function SubmitPageClient({ planets, userFactions, planetSystems,
             planetSystems={planetSystems}
             currentUserId={currentUserId}
           />
+        ) : kind === 'loremaster' ? (
+          <LoremasterSubmitForm
+            planets={planets}
+            userFactions={userFactions}
+            currentUserId={currentUserId}
+          />
         ) : (
           <SimpleSubmitForm
             kind={kind}
@@ -84,12 +93,12 @@ export default function SubmitPageClient({ planets, userFactions, planetSystems,
 }
 
 // -----------------------------------------------------------------
-// Simple (painted / lore) form — no game system / adversary fields.
+// Simple (painted / scribe) form — no game system / adversary fields.
 // -----------------------------------------------------------------
 function SimpleSubmitForm({
   kind, planets, userFactions, currentUserId,
 }: {
-  kind: 'painted' | 'lore';
+  kind: 'painted' | 'scribe';
   planets: Planet[];
   userFactions: Faction[];
   currentUserId: string;
@@ -103,10 +112,8 @@ function SimpleSubmitForm({
   const [description, setDescription] = useState('');
   const [imageUrl, setImageUrl] = useState('');
   const [imageFile, setImageFile] = useState<File | null>(null);
-  // Use the canonical POINT_PRESETS from lib/types.ts so the initial value
-  // matches one of the tile options (see #2 and the painted/lore tile change).
   const [points, setPoints] = useState<number>(
-    kind === 'painted' ? POINT_PRESETS.model[0].value : POINT_PRESETS.lore[0].value,
+    kind === 'painted' ? POINT_PRESETS.model[0].value : POINT_PRESETS.scribe[0].value,
   );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -135,10 +142,7 @@ function SimpleSubmitForm({
       }
     }
 
-    // UI uses 'painted' / 'lore' / 'battle' for tab kinds; the DB
-    // submission_type enum is ('game', 'model', 'lore', 'bonus'), so
-    // map 'painted' -> 'model' before insert. (Battle submissions go
-    // through BattleSubmitForm which maps 'battle' -> 'game'.)
+    // UI tab id 'painted' maps to DB enum 'model'; 'scribe' is itself a DB enum value.
     const dbType = kind === 'painted' ? 'model' : kind;
     const { error: err } = await supabase.from('submissions').insert({
       player_id:  currentUserId,
@@ -213,7 +217,7 @@ function SimpleSubmitForm({
         <textarea
           value={description}
           onChange={(e) => setDescription(e.target.value)}
-          rows={kind === 'lore' ? 8 : 4}
+          rows={kind === 'scribe' ? 8 : 4}
           className="input w-full"
         />
       </label>
@@ -276,7 +280,7 @@ function SimpleSubmitForm({
         <div>
           <span className="label">Claimed points</span>
           <div className="mt-1 grid grid-cols-1 gap-2 sm:grid-cols-3">
-            {POINT_PRESETS.lore.map((opt) => (
+            {POINT_PRESETS.scribe.map((opt) => (
               <button
                 key={opt.value}
                 type="button"
@@ -297,6 +301,257 @@ function SimpleSubmitForm({
           </p>
         </div>
       )}
+
+      {error && (
+        <div className="border border-blood bg-blood/20 px-3 py-2 text-sm text-parchment">
+          {error}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={submitting || userFactions.length === 0}
+        className="btn-primary disabled:opacity-50"
+      >
+        {submitting ? 'Submitting…' : 'Submit for Approval'}
+      </button>
+    </form>
+  );
+}
+
+// -----------------------------------------------------------------
+// Loremaster (reading / listening) form. Captures title, format,
+// star rating, and a short reflection. Glory is fixed at 1 point.
+// -----------------------------------------------------------------
+const REFLECTION_MIN = 50;
+const REFLECTION_MAX = 500;
+
+function LoremasterSubmitForm({
+  planets, userFactions, currentUserId,
+}: {
+  planets: Planet[];
+  userFactions: Faction[];
+  currentUserId: string;
+}) {
+  const router = useRouter();
+  const supabase = useMemo(() => createClient(), []);
+
+  const [planetId, setPlanetId] = useState(planets[0]?.id ?? '');
+  const [factionId, setFactionId] = useState(userFactions[0]?.id ?? '');
+  const [loreTitle, setLoreTitle] = useState('');
+  const [format, setFormat] = useState<LoreFormat>('novel');
+  const [rating, setRating] = useState<number>(0);
+  const [reflection, setReflection] = useState('');
+  const [imageUrl, setImageUrl] = useState('');
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reflectionLen = reflection.trim().length;
+  const reflectionValid = reflectionLen >= REFLECTION_MIN && reflectionLen <= REFLECTION_MAX;
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!planetId || !factionId) {
+      setError('Planet and faction are required.');
+      return;
+    }
+    if (!loreTitle.trim()) {
+      setError('Title is required.');
+      return;
+    }
+    if (rating < 1 || rating > 5) {
+      setError('Pick a rating between 1 and 5 stars.');
+      return;
+    }
+    if (!reflectionValid) {
+      setError(`Reflection must be ${REFLECTION_MIN}–${REFLECTION_MAX} characters.`);
+      return;
+    }
+    setSubmitting(true);
+
+    let finalImageUrl: string | null = imageUrl.trim() || null;
+    if (imageFile) {
+      try {
+        finalImageUrl = await uploadImage(imageFile);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Image upload failed.');
+        setSubmitting(false);
+        return;
+      }
+    }
+
+    const trimmedTitle = loreTitle.trim();
+    const trimmedReflection = reflection.trim();
+
+    const { error: err } = await supabase.from('submissions').insert({
+      player_id:        currentUserId,
+      type:             'loremaster',
+      status:           'pending',
+      target_planet_id: planetId,
+      faction_id:       factionId,
+      title:            trimmedTitle,
+      body:             trimmedReflection,
+      image_url:        finalImageUrl,
+      points:           1,
+      lore_title:       trimmedTitle,
+      lore_format:      format,
+      lore_rating:      rating,
+      lore_reflection:  trimmedReflection,
+    });
+    setSubmitting(false);
+    if (err) { setError(err.message); return; }
+    router.push('/dashboard?submitted=1');
+    router.refresh();
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <label className="block">
+        <span className="label">Planet</span>
+        <select
+          value={planetId}
+          onChange={(e) => setPlanetId(e.target.value)}
+          className="input w-full bg-ink text-parchment"
+        >
+          {planets.map((p) => (
+            <option key={p.id} value={p.id} className="bg-ink text-parchment">
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="block">
+        <span className="label">Faction</span>
+        <select
+          value={factionId}
+          onChange={(e) => setFactionId(e.target.value)}
+          className="input w-full bg-ink text-parchment"
+        >
+          {userFactions.length === 0 ? (
+            <option value="" className="bg-ink text-parchment">(Join a faction first)</option>
+          ) : (
+            userFactions.map((f) => (
+              <option key={f.id} value={f.id} className="bg-ink text-parchment">{f.name}</option>
+            ))
+          )}
+        </select>
+      </label>
+
+      <label className="block">
+        <span className="label">Title</span>
+        <input
+          type="text"
+          value={loreTitle}
+          onChange={(e) => setLoreTitle(e.target.value)}
+          className="input w-full"
+          placeholder="The Horus Heresy: Horus Rising"
+          required
+        />
+      </label>
+
+      <div>
+        <span className="label">Format</span>
+        <div className="mt-1 grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {([
+            { id: 'novel',     label: 'Novel / omnibus',         icon: '📕' },
+            { id: 'audiobook', label: 'Audiobook / audio drama', icon: '🎧' },
+          ] as const).map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => setFormat(opt.id)}
+              className={`flex items-center justify-center gap-2 rounded border px-3 py-2 text-sm transition-colors hover:border-brass/50 ${
+                format === opt.id
+                  ? 'border-brass bg-brass/10 text-parchment'
+                  : 'border-brass/20 text-parchment-dim'
+              }`}
+            >
+              <span aria-hidden>{opt.icon}</span>
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <span className="label">Rating</span>
+        <div className="mt-1 flex items-center gap-1">
+          {[1, 2, 3, 4, 5].map((n) => {
+            const active = n <= rating;
+            return (
+              <button
+                key={n}
+                type="button"
+                onClick={() => setRating(n)}
+                aria-label={`${n} star${n === 1 ? '' : 's'}`}
+                className={`text-2xl transition-colors ${
+                  active ? 'text-brass-bright' : 'text-parchment-dark hover:text-brass'
+                }`}
+              >
+                {active ? '★' : '☆'}
+              </button>
+            );
+          })}
+          <span className="ml-2 text-xs text-parchment-dark">
+            {rating === 0 ? 'Pick a rating' : `${rating} / 5`}
+          </span>
+        </div>
+      </div>
+
+      <label className="block">
+        <span className="label">Reflection</span>
+        <p className="mb-1 text-xs italic text-parchment-dark">
+          In a sentence or two, what stuck with you? A revelation about your faction, a memorable
+          character moment, or a piece of lore that changes how you see the galaxy…
+        </p>
+        <textarea
+          value={reflection}
+          onChange={(e) => setReflection(e.target.value)}
+          rows={5}
+          className="input w-full"
+          minLength={REFLECTION_MIN}
+          maxLength={REFLECTION_MAX}
+          required
+        />
+        <p className={`mt-1 text-xs ${reflectionValid || reflectionLen === 0 ? 'text-parchment-dark' : 'text-blood'}`}>
+          {reflectionLen} / {REFLECTION_MAX} characters {reflectionLen < REFLECTION_MIN && `(min ${REFLECTION_MIN})`}
+        </p>
+      </label>
+
+      <div>
+        <span className="label">
+          Image <span className="text-parchment-dark normal-case">(optional — book cover, Audible screenshot, etc.)</span>
+        </span>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setImageFile(e.target.files?.[0] ?? null)}
+          className="input w-full file:bg-brass-dark file:text-parchment file:border-0 file:px-3 file:py-1 file:mr-3 file:font-display file:uppercase file:text-xs file:tracking-wider"
+        />
+        <label className="mt-3 block">
+          <span className="label">Or paste an image URL</span>
+          <input
+            type="url"
+            value={imageUrl}
+            onChange={(e) => setImageUrl(e.target.value)}
+            placeholder="https://…"
+            className="input w-full"
+            disabled={!!imageFile}
+          />
+        </label>
+        {imageFile && (
+          <p className="mt-1 text-xs italic text-parchment-dark">
+            Uploading {imageFile.name} on submit. Clear the file to use a URL instead.
+          </p>
+        )}
+      </div>
+
+      <p className="text-xs italic text-parchment-dark">
+        Lore deeds are worth a fixed 1 glory.
+      </p>
 
       {error && (
         <div className="border border-blood bg-blood/20 px-3 py-2 text-sm text-parchment">

--- a/app/submit/page.tsx
+++ b/app/submit/page.tsx
@@ -5,10 +5,8 @@
 // system allowlist) and hands it off to a client wrapper that lets the
 // user pick which kind of submission they're making.
 //
-// For 'battle' kind, uses the new BattleSubmitForm.
-// For 'painted' / 'lore' / 'bonus' we render a simpler form inline so
-// the submit page works end-to-end. If you already have richer forms
-// for those kinds, swap in your existing components.
+// 'battle' uses BattleSubmitForm; 'loremaster' has its own form for
+// format/rating/reflection; 'painted' and 'scribe' share SimpleSubmitForm.
 // =====================================================================
 
 import { redirect } from 'next/navigation';

--- a/components/KindBadge.tsx
+++ b/components/KindBadge.tsx
@@ -6,10 +6,11 @@ const ALIAS: Record<string, string> = { game: 'battle', model: 'painted' };
 export default function KindBadge({ kind }: { kind: string }) {
   const normalized = ALIAS[kind] ?? kind;
   const map: Record<string, { label: string; cls: string; icon: string }> = {
-    battle:  { label: 'Battle',  cls: 'border-red-700/60    bg-red-900/30    text-red-200',    icon: '⚔' },
-    painted: { label: 'Painted', cls: 'border-blue-700/60   bg-blue-900/30   text-blue-200',   icon: '🖌' },
-    lore:    { label: 'Lore',    cls: 'border-amber-700/60  bg-amber-900/30  text-amber-200',  icon: '📜' },
-    bonus:   { label: 'Bonus',   cls: 'border-purple-700/60 bg-purple-900/30 text-purple-200', icon: '✦' },
+    battle:     { label: 'Battle',     cls: 'border-red-700/60    bg-red-900/30    text-red-200',    icon: '⚔' },
+    painted:    { label: 'Painted',    cls: 'border-blue-700/60   bg-blue-900/30   text-blue-200',   icon: '🖌' },
+    scribe:     { label: 'Scribe',     cls: 'border-amber-700/60  bg-amber-900/30  text-amber-200',  icon: '📜' },
+    loremaster: { label: 'Loremaster', cls: 'border-indigo-700/60 bg-indigo-900/30 text-indigo-200', icon: '📖' },
+    bonus:      { label: 'Bonus',      cls: 'border-purple-700/60 bg-purple-900/30 text-purple-200', icon: '✦' },
   };
   const cfg = map[normalized] ?? { label: normalized, cls: 'border-brass/40 bg-brass/20 text-brass-bright', icon: '✠' };
   return (

--- a/lib/types.additions.ts
+++ b/lib/types.additions.ts
@@ -85,9 +85,11 @@ export interface EloConfig {
   k_factor: number;
 }
 
+export type LoreFormat = 'novel' | 'audiobook';
+
 export interface ActivityFeedItem {
   submission_id: string;
-  kind: 'battle' | 'painted' | 'lore' | 'bonus' | string;
+  kind: 'battle' | 'painted' | 'scribe' | 'loremaster' | 'bonus' | string;
   status: 'approved';
   created_at: string;
   title: string | null;
@@ -96,6 +98,9 @@ export interface ActivityFeedItem {
   points: number | null;
   result: BattleResult | null;
   game_size: GameSize | null;
+  lore_title: string | null;
+  lore_format: LoreFormat | null;
+  lore_rating: number | null;
   user_id: string | null;
   display_name: string;
   avatar_url: string | null;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,9 +28,10 @@ export type Planet = {
   created_at: string;
 };
 
-export type SubmissionType = "game" | "model" | "lore" | "bonus";
+export type SubmissionType = "game" | "model" | "scribe" | "loremaster" | "bonus";
 export type SubmissionStatus = "pending" | "approved" | "rejected";
 export type GameResult = "win" | "loss" | "draw";
+export type LoreFormat = "novel" | "audiobook";
 
 export type Submission = {
   id: string;
@@ -49,6 +50,10 @@ export type Submission = {
   reviewed_at: string | null;
   review_notes: string | null;
   created_at: string;
+  lore_title: string | null;
+  lore_format: LoreFormat | null;
+  lore_rating: number | null;
+  lore_reflection: string | null;
 };
 
 export type FactionTotal = {
@@ -58,7 +63,8 @@ export type FactionTotal = {
   total_points: number;
   wins: number;
   models_painted: number;
-  lore_submitted: number;
+  lore_written: number;
+  lore_read: number;
   planets_controlled: number;
 };
 
@@ -95,10 +101,13 @@ export const POINT_PRESETS: Record<SubmissionType, { label: string; value: numbe
     { label: "Vehicle / monster", value: 8 },
     { label: "Titanic", value: 25 },
   ],
-  lore: [
+  scribe: [
     { label: "Short vignette (<500 words)", value: 3 },
     { label: "Short story (500-1500 words)", value: 6 },
     { label: "Long-form narrative (1500+ words)", value: 10 },
+  ],
+  loremaster: [
+    { label: "Lore deed", value: 1 },
   ],
   bonus: [
     { label: "Small bonus", value: 5 },
@@ -193,7 +202,7 @@ export interface EloConfig {
 
 export interface ActivityFeedItem {
   submission_id: string;
-  kind: 'battle' | 'painted' | 'lore' | 'bonus' | string;
+  kind: 'battle' | 'painted' | 'scribe' | 'loremaster' | 'bonus' | string;
   status: 'approved';
   created_at: string;
   title: string | null;
@@ -202,6 +211,9 @@ export interface ActivityFeedItem {
   points: number | null;
   result: BattleResult | null;
   game_size: GameSize | null;
+  lore_title: string | null;
+  lore_format: LoreFormat | null;
+  lore_rating: number | null;
   user_id: string | null;
   display_name: string;
   avatar_url: string | null;

--- a/supabase/migrations/0009_lore_split_enum.sql
+++ b/supabase/migrations/0009_lore_split_enum.sql
@@ -1,0 +1,358 @@
+-- ============================================================================
+-- 0009_lore_split_enum.sql
+--
+-- Issue #31 part 1 of 2: split the `lore` submission type into two distinct
+-- types — writing (renamed to `scribe`) and reading/listening (`loremaster`,
+-- added in this migration). Issue #31 introduces the reading deed for novels
+-- and audiobooks; the existing `lore` enum value semantically meant *writing*
+-- fluff, so it's renamed for symmetry.
+--
+-- This phase ONLY:
+--   1. Renames the enum value `lore` → `scribe`.
+--   2. Adds the new `loremaster` enum value (cannot be referenced until the
+--      next migration commits — Postgres restriction on ALTER TYPE ADD VALUE).
+--   3. Recreates `faction_totals` to read `s.type = 'scribe'` and renames the
+--      column `lore_submitted` → `lore_written`. The companion `lore_read`
+--      column is added in 0010, once `loremaster` is referenceable.
+--   4. Updates evaluator functions to use `'scribe'` instead of `'lore'` so
+--      existing writing-track awards keep firing.
+--   5. Renames the existing badge key `loremaster` → `master_scribe`. The
+--      badge name and description are unchanged. This avoids a confusing
+--      collision between the badge key and the new submission type, both
+--      called `loremaster`.
+--
+-- 0010 then adds the loremaster-specific columns, the new badges, and the
+-- evaluator logic that grants them.
+-- ============================================================================
+
+-- ---------- 1. RENAME ENUM VALUE ----------
+alter type public.submission_type rename value 'lore' to 'scribe';
+
+-- ---------- 2. ADD NEW ENUM VALUE ----------
+-- IMPORTANT: 'loremaster' cannot be referenced in queries within this same
+-- transaction. 0010 uses it freely.
+alter type public.submission_type add value if not exists 'loremaster';
+
+-- ---------- 3. REBUILD faction_totals VIEW ----------
+-- Rename `lore_submitted` → `lore_written` for the writing track. The
+-- companion `lore_read` column is added in 0010.
+drop view if exists public.faction_totals;
+
+create view public.faction_totals as
+  select
+    f.id as faction_id,
+    f.name as faction_name,
+    f.color,
+    coalesce(sum(s.points), 0)::int as total_points,
+    count(s.id) filter (where s.type = 'game' and s.result = 'win') as wins,
+    count(s.id) filter (where s.type = 'model') as models_painted,
+    count(s.id) filter (where s.type = 'scribe') as lore_written,
+    count(distinct p.id) as planets_controlled
+  from public.factions f
+  left join public.submissions s
+    on s.faction_id = f.id and s.status = 'approved'
+  left join public.planets p
+    on p.controlling_faction_id = f.id
+  group by f.id, f.name, f.color;
+
+grant select on public.faction_totals to anon, authenticated;
+
+-- ---------- 4. UPDATE EVALUATORS TO USE 'scribe' ----------
+-- The existing 4 lore-track awards (remembrancer, chronicler, loremaster
+-- badge, keeper_of_secrets) all rewarded *written* lore. Re-bind their
+-- queries to the renamed enum value.
+
+create or replace function public.evaluate_player_awards(p_player_id uuid)
+returns void
+language plpgsql
+security definer
+as $$
+declare
+  v_game_count     int;
+  v_model_count    int;
+  v_lore_count     int;
+  v_max_streak     int;
+  v_distinct_types int;
+  v_total_types    int;
+  v_creation_rank  int;
+begin
+  if p_player_id is null then return; end if;
+
+  -- Combat: total approved games (incl. mirrors)
+  select count(*) into v_game_count
+  from public.submissions
+  where player_id = p_player_id and type = 'game' and status = 'approved';
+
+  if v_game_count >= 1  then perform public._grant_award(p_player_id, 'first_blood'); end if;
+  if v_game_count >= 3  then perform public._grant_award(p_player_id, 'veteran'); end if;
+  if v_game_count >= 10 then perform public._grant_award(p_player_id, 'honored_of_the_chapter'); end if;
+
+  -- Win streak
+  v_max_streak := public._max_win_streak(p_player_id);
+  if v_max_streak >= 3  then perform public._grant_award(p_player_id, 'double_tap'); end if;
+  if v_max_streak >= 5  then perform public._grant_award(p_player_id, 'overkill'); end if;
+  if v_max_streak >= 10 then perform public._grant_award(p_player_id, 'exterminatus'); end if;
+
+  -- Nemesis: 3+ wins against same linked adversary
+  if exists (
+    select 1
+    from public.submissions
+    where player_id = p_player_id
+      and status = 'approved'
+      and type = 'game'
+      and result = 'win'
+      and adversary_user_id is not null
+    group by adversary_user_id
+    having count(*) >= 3
+  ) then
+    perform public._grant_award(p_player_id, 'nemesis');
+  end if;
+
+  -- David: any winning linked battle whose ELO delta exceeds K/2
+  if exists (
+    select 1
+    from public.submissions s
+    join public.elo_config ec on ec.game_system_id = s.game_system_id
+    where s.player_id = p_player_id
+      and s.status = 'approved'
+      and s.type = 'game'
+      and s.result = 'win'
+      and s.adversary_user_id is not null
+      and s.elo_delta is not null
+      and s.elo_delta::numeric > (ec.k_factor::numeric / 2)
+  ) then
+    perform public._grant_award(p_player_id, 'david');
+  end if;
+
+  -- Painting: total approved model submissions
+  select count(*) into v_model_count
+  from public.submissions
+  where player_id = p_player_id and type = 'model' and status = 'approved';
+
+  if v_model_count >= 1  then perform public._grant_award(p_player_id, 'brush_initiate'); end if;
+  if v_model_count >= 3  then perform public._grant_award(p_player_id, 'production_painter'); end if;
+  if v_model_count >= 10 then perform public._grant_award(p_player_id, 'master_artisan'); end if;
+
+  if public._has_3_consecutive_painting_months(p_player_id) then
+    perform public._grant_award(p_player_id, 'the_long_vigil');
+  end if;
+
+  -- Lore (writing track) — type renamed from 'lore' to 'scribe' in 0009.
+  -- Badge key renamed from 'loremaster' to 'master_scribe' (same migration).
+  select count(*) into v_lore_count
+  from public.submissions
+  where player_id = p_player_id and type = 'scribe' and status = 'approved';
+
+  if v_lore_count >= 1  then perform public._grant_award(p_player_id, 'remembrancer'); end if;
+  if v_lore_count >= 3  then perform public._grant_award(p_player_id, 'chronicler'); end if;
+  if v_lore_count >= 10 then perform public._grant_award(p_player_id, 'master_scribe'); end if;
+
+  -- Conquest: Planetfall
+  if exists (
+    select 1
+    from public.submissions s
+    join public.planets p on p.id = s.target_planet_id
+    where s.player_id = p_player_id
+      and s.status = 'approved'
+      and s.faction_id is not null
+      and p.controlling_faction_id = s.faction_id
+  ) then
+    perform public._grant_award(p_player_id, 'planetfall');
+  end if;
+
+  -- Holdfast — submission posted after a flip that gave that faction control.
+  if exists (
+    select 1
+    from public.planet_flip_log pfl
+    join public.submissions s
+      on s.target_planet_id = pfl.planet_id
+     and s.faction_id       = pfl.gained_faction_id
+     and s.status            = 'approved'
+     and s.created_at        > pfl.created_at
+    where s.player_id = p_player_id
+  ) then
+    perform public._grant_award(p_player_id, 'holdfast');
+  end if;
+
+  -- World Eater — was the top points contributor at any planet flip.
+  if exists (
+    select 1 from public.planet_flip_log
+    where top_contributor_id = p_player_id
+  ) then
+    perform public._grant_award(p_player_id, 'world_eater');
+  end if;
+
+  -- Crusade Architect — contributed to flips on 3+ different planets.
+  if (
+    select count(distinct pfl.planet_id)
+    from public.planet_flip_log pfl
+    where exists (
+      select 1 from public.submissions s
+      where s.player_id        = p_player_id
+        and s.target_planet_id = pfl.planet_id
+        and s.faction_id       = pfl.gained_faction_id
+        and s.status            = 'approved'
+        and s.created_at        <= pfl.created_at
+    )
+  ) >= 3 then
+    perform public._grant_award(p_player_id, 'crusade_architect');
+  end if;
+
+  -- Accept Any Challenge: one approved submission of every enum value.
+  select count(distinct type) into v_distinct_types
+  from public.submissions
+  where player_id = p_player_id and status = 'approved';
+
+  v_total_types := array_length(enum_range(null::public.submission_type), 1);
+
+  if v_distinct_types is not null
+     and v_total_types is not null
+     and v_distinct_types >= v_total_types then
+    perform public._grant_award(p_player_id, 'accept_any_challenge');
+  end if;
+
+  -- Faithful Servant: 12 consecutive weeks of approved submissions.
+  if public._has_12_consecutive_weeks(p_player_id) then
+    perform public._grant_award(p_player_id, 'faithful_servant');
+  end if;
+
+  -- Veteran of the Long War: one of the first 10 accounts created.
+  select rnk into v_creation_rank
+  from (
+    select id, dense_rank() over (order by created_at) as rnk
+    from public.profiles
+  ) t
+  where t.id = p_player_id;
+
+  if v_creation_rank is not null and v_creation_rank <= 10 then
+    perform public._grant_award(p_player_id, 'veteran_of_the_long_war');
+  end if;
+end $$;
+
+-- ---------- 5. UPDATE COMPETITIVE EVALUATOR TO USE 'scribe' ----------
+create or replace function public.evaluate_competitive_awards()
+returns void
+language plpgsql
+security definer
+as $$
+declare
+  v_warmaster   uuid;
+  v_painter     uuid;
+  v_lorekeeper  uuid;
+  v_global_top  uuid;
+  r record;
+begin
+  -- Warmaster
+  select player_id into v_warmaster
+  from (
+    select player_id, count(*) as cnt
+    from public.submissions
+    where type = 'game' and status = 'approved'
+    group by player_id
+  ) t
+  where cnt >= 20
+  order by cnt desc, player_id asc
+  limit 1;
+
+  delete from public.player_awards pa
+  using public.awards a
+  where pa.award_id = a.id
+    and a.key = 'warmaster'
+    and (v_warmaster is null or pa.player_id <> v_warmaster);
+
+  if v_warmaster is not null then
+    perform public._grant_award(v_warmaster, 'warmaster');
+  end if;
+
+  -- Painting Daemon
+  select player_id into v_painter
+  from (
+    select player_id, count(*) as cnt
+    from public.submissions
+    where type = 'model' and status = 'approved'
+    group by player_id
+  ) t
+  where cnt >= 20
+  order by cnt desc, player_id asc
+  limit 1;
+
+  delete from public.player_awards pa
+  using public.awards a
+  where pa.award_id = a.id
+    and a.key = 'painting_daemon'
+    and (v_painter is null or pa.player_id <> v_painter);
+
+  if v_painter is not null then
+    perform public._grant_award(v_painter, 'painting_daemon');
+  end if;
+
+  -- Keeper of Secrets — most approved writing-track lore, ≥ 20.
+  -- Type renamed from 'lore' to 'scribe' in this migration.
+  select player_id into v_lorekeeper
+  from (
+    select player_id, count(*) as cnt
+    from public.submissions
+    where type = 'scribe' and status = 'approved'
+    group by player_id
+  ) t
+  where cnt >= 20
+  order by cnt desc, player_id asc
+  limit 1;
+
+  delete from public.player_awards pa
+  using public.awards a
+  where pa.award_id = a.id
+    and a.key = 'keeper_of_secrets'
+    and (v_lorekeeper is null or pa.player_id <> v_lorekeeper);
+
+  if v_lorekeeper is not null then
+    perform public._grant_award(v_lorekeeper, 'keeper_of_secrets');
+  end if;
+
+  -- First Among Equals
+  select player_id into v_global_top
+  from public.player_totals
+  where total_points >= 50
+  order by total_points desc, player_id asc
+  limit 1;
+
+  delete from public.player_awards pa
+  using public.awards a
+  where pa.award_id = a.id
+    and a.key = 'first_among_equals'
+    and (v_global_top is null or pa.player_id <> v_global_top);
+
+  if v_global_top is not null then
+    perform public._grant_award(v_global_top, 'first_among_equals');
+  end if;
+
+  -- Standard Bearer
+  delete from public.player_awards pa
+  using public.awards a
+  where pa.award_id = a.id
+    and a.key = 'standard_bearer'
+    and pa.player_id not in (
+      select distinct on (faction_id) player_id
+      from public.player_totals
+      where faction_id is not null and total_points >= 30
+      order by faction_id, total_points desc, player_id asc
+    );
+
+  for r in
+    select distinct on (faction_id) player_id
+    from public.player_totals
+    where faction_id is not null and total_points >= 30
+    order by faction_id, total_points desc, player_id asc
+  loop
+    perform public._grant_award(r.player_id, 'standard_bearer');
+  end loop;
+end $$;
+
+-- ---------- 6. RENAME EXISTING BADGE KEY ----------
+-- The existing `loremaster` badge (10 written entries, honoured tier) is
+-- renamed to `master_scribe` so its key doesn't collide with the new
+-- `loremaster` submission type. Player_awards rows reference the badge by id,
+-- so earned badges survive the rename.
+update public.awards
+set key = 'master_scribe'
+where key = 'loremaster';

--- a/supabase/migrations/0010_loremaster_features.sql
+++ b/supabase/migrations/0010_loremaster_features.sql
@@ -1,0 +1,518 @@
+-- ============================================================================
+-- 0010_loremaster_features.sql
+--
+-- Issue #31 part 2 of 2: build out the loremaster (reading/listening) deed
+-- type that 0009 added to the enum. This migration:
+--
+--   1. Adds reading-specific columns on `submissions` (lore_title,
+--      lore_format, lore_rating, lore_reflection) with CHECK constraints.
+--   2. Rebuilds `faction_totals` to add the companion `lore_read` column.
+--   3. Rebuilds `activity_feed` to surface the new columns so the public
+--      submission detail and admin queue can render format / rating /
+--      reflection without an extra round trip.
+--   4. Inserts six new awards in the `lore` category (cosmetic only — no
+--      glory points awarded by these badges).
+--   5. Adds the `_has_12_consecutive_loremaster_months` helper.
+--   6. Extends `evaluate_player_awards` with reading-track logic.
+--   7. Extends `evaluate_competitive_awards` with the Astropathic Choir
+--      (group achievement: every active player ≥1 reading deed in the
+--      same calendar month).
+--   8. Backfills the per-player evaluator + competitive evaluator so any
+--      pre-existing data that already qualifies grants the new badges.
+-- ============================================================================
+
+-- ---------- 1. NEW SUBMISSION COLUMNS ----------
+alter table public.submissions
+  add column if not exists lore_title      text,
+  add column if not exists lore_format     text
+    check (lore_format is null or lore_format in ('novel','audiobook')),
+  add column if not exists lore_rating     smallint
+    check (lore_rating is null or lore_rating between 1 and 5),
+  add column if not exists lore_reflection text;
+
+comment on column public.submissions.lore_title is
+  'Non-null for type=loremaster: book or audio drama title.';
+comment on column public.submissions.lore_format is
+  'Non-null for type=loremaster: novel or audiobook.';
+comment on column public.submissions.lore_rating is
+  'Non-null for type=loremaster: 1-5 star rating.';
+comment on column public.submissions.lore_reflection is
+  'Non-null for type=loremaster: 50-500 char proof-of-engagement.';
+
+-- ---------- 2. REBUILD faction_totals WITH lore_read ----------
+drop view if exists public.faction_totals;
+
+create view public.faction_totals as
+  select
+    f.id as faction_id,
+    f.name as faction_name,
+    f.color,
+    coalesce(sum(s.points), 0)::int as total_points,
+    count(s.id) filter (where s.type = 'game' and s.result = 'win') as wins,
+    count(s.id) filter (where s.type = 'model') as models_painted,
+    count(s.id) filter (where s.type = 'scribe') as lore_written,
+    count(s.id) filter (where s.type = 'loremaster') as lore_read,
+    count(distinct p.id) as planets_controlled
+  from public.factions f
+  left join public.submissions s
+    on s.faction_id = f.id and s.status = 'approved'
+  left join public.planets p
+    on p.controlling_faction_id = f.id
+  group by f.id, f.name, f.color;
+
+grant select on public.faction_totals to anon, authenticated;
+
+-- ---------- 3. REBUILD activity_feed WITH LORE COLUMNS ----------
+-- The public detail page reads from this view. Add lore_title/format/rating
+-- so the loremaster renderer doesn't need a second query. (lore_reflection
+-- is surfaced via the existing `description` column when the submission is
+-- a loremaster; the form writes its reflection into both s.body and
+-- s.lore_reflection so the existing description path keeps working.)
+drop view if exists public.activity_feed;
+
+create view public.activity_feed as
+select
+  s.id                              as submission_id,
+  case s.type
+    when 'game'  then 'battle'
+    when 'model' then 'painted'
+    else s.type::text
+  end::text                         as kind,
+  s.status,
+  s.created_at,
+  s.title,
+  s.body                            as description,
+  s.image_url,
+  s.points,
+  s.result,
+  s.game_size,
+  s.lore_title,
+  s.lore_format,
+  s.lore_rating,
+  p.id                              as user_id,
+  coalesce(p.display_name, 'Unknown Commander') as display_name,
+  p.avatar_url,
+  f.id                              as faction_id,
+  f.name                            as faction_name,
+  f.color                           as faction_color,
+  pl.id                             as planet_id,
+  pl.name                           as planet_name,
+  gs.id                             as game_system_id,
+  gs.short_name                     as game_system_short,
+  gs.name                           as game_system_name,
+  adv.id                            as adversary_user_id,
+  coalesce(adv.display_name, s.opponent_name) as adversary_name,
+  advf.name                         as adversary_faction_name,
+  advf.color                        as adversary_faction_color,
+  vgt.name                          as video_game_name
+from public.submissions s
+left join public.profiles    p    on p.id = s.player_id
+left join public.factions    f    on f.id = s.faction_id
+left join public.planets     pl   on pl.id = s.target_planet_id
+left join public.game_systems gs  on gs.id = s.game_system_id
+left join public.profiles    adv  on adv.id = s.adversary_user_id
+left join public.factions    advf on advf.id = s.adversary_faction_id
+left join public.video_game_titles vgt on vgt.id = s.video_game_title_id
+where s.status = 'approved';
+
+grant select on public.activity_feed to anon, authenticated;
+
+-- ---------- 4. SEED NEW AWARDS ----------
+insert into public.awards (key, name, description, hint, tier, category, icon, sort_order) values
+  ('seeker_of_truth',             'Seeker of Truth',             'Recorded your first novel.',                              'Read your first Black Library tome.',                       'common',     'lore', '📕', 304),
+  ('vox_logged',                  'Vox-Logged',                  'Recorded your first audio drama.',                        'Hear the vox-cast for the first time.',                     'common',     'lore', '🎧', 305),
+  ('witness_of_the_word',         'Witness of the Word',         'Fifteen approved reading deeds across novels and audio.', 'Read or listen fifteen times over.',                        'honoured',   'lore', '📚', 306),
+  ('keeper_of_the_black_library', 'Keeper of the Black Library', 'One hundred approved reading deeds. Cegorach himself takes notice.', 'Walk the stacks of the Black Library a hundred times.',     'legendary',  'lore', '🏛', 307),
+  ('astropathic_choir',           'Astropathic Choir',           'Every active commander logged a lore reading in the same month — and you were one of them.', 'A reading vigil joined by every active commander.',         'adamantium', 'lore', '🔱', 308),
+  ('eternal_witness',             'The Eternal Witness',         'Logged at least one reading deed every month for twelve consecutive months.', 'Twelve months without a silent vigil.',                     'adamantium', 'lore', '👁', 309)
+on conflict (key) do nothing;
+
+-- ---------- 5. CONSECUTIVE-MONTHS HELPER ----------
+create or replace function public._has_12_consecutive_loremaster_months(p_player_id uuid)
+returns boolean
+language plpgsql
+stable
+as $$
+declare
+  r record;
+  prev_month date := null;
+  streak int := 0;
+begin
+  for r in
+    select distinct date_trunc('month', created_at)::date as m
+    from public.submissions
+    where player_id = p_player_id
+      and type = 'loremaster'
+      and status = 'approved'
+    order by m
+  loop
+    if prev_month is null then
+      streak := 1;
+    elsif r.m = prev_month + interval '1 month' then
+      streak := streak + 1;
+    else
+      streak := 1;
+    end if;
+    if streak >= 12 then return true; end if;
+    prev_month := r.m;
+  end loop;
+  return false;
+end $$;
+
+-- ---------- 6. EXTEND PER-PLAYER EVALUATOR ----------
+-- Adds reading-track logic alongside the writing-track checks already wired
+-- by 0009. Astropathic Choir is granted by the competitive evaluator below
+-- (group achievement, not per-player threshold).
+create or replace function public.evaluate_player_awards(p_player_id uuid)
+returns void
+language plpgsql
+security definer
+as $$
+declare
+  v_game_count        int;
+  v_model_count       int;
+  v_lore_count        int;
+  v_loremaster_count  int;
+  v_novel_count       int;
+  v_audiobook_count   int;
+  v_max_streak        int;
+  v_distinct_types    int;
+  v_total_types       int;
+  v_creation_rank     int;
+begin
+  if p_player_id is null then return; end if;
+
+  -- Combat: total approved games
+  select count(*) into v_game_count
+  from public.submissions
+  where player_id = p_player_id and type = 'game' and status = 'approved';
+
+  if v_game_count >= 1  then perform public._grant_award(p_player_id, 'first_blood'); end if;
+  if v_game_count >= 3  then perform public._grant_award(p_player_id, 'veteran'); end if;
+  if v_game_count >= 10 then perform public._grant_award(p_player_id, 'honored_of_the_chapter'); end if;
+
+  -- Win streak
+  v_max_streak := public._max_win_streak(p_player_id);
+  if v_max_streak >= 3  then perform public._grant_award(p_player_id, 'double_tap'); end if;
+  if v_max_streak >= 5  then perform public._grant_award(p_player_id, 'overkill'); end if;
+  if v_max_streak >= 10 then perform public._grant_award(p_player_id, 'exterminatus'); end if;
+
+  -- Nemesis
+  if exists (
+    select 1
+    from public.submissions
+    where player_id = p_player_id
+      and status = 'approved'
+      and type = 'game'
+      and result = 'win'
+      and adversary_user_id is not null
+    group by adversary_user_id
+    having count(*) >= 3
+  ) then
+    perform public._grant_award(p_player_id, 'nemesis');
+  end if;
+
+  -- David
+  if exists (
+    select 1
+    from public.submissions s
+    join public.elo_config ec on ec.game_system_id = s.game_system_id
+    where s.player_id = p_player_id
+      and s.status = 'approved'
+      and s.type = 'game'
+      and s.result = 'win'
+      and s.adversary_user_id is not null
+      and s.elo_delta is not null
+      and s.elo_delta::numeric > (ec.k_factor::numeric / 2)
+  ) then
+    perform public._grant_award(p_player_id, 'david');
+  end if;
+
+  -- Painting
+  select count(*) into v_model_count
+  from public.submissions
+  where player_id = p_player_id and type = 'model' and status = 'approved';
+
+  if v_model_count >= 1  then perform public._grant_award(p_player_id, 'brush_initiate'); end if;
+  if v_model_count >= 3  then perform public._grant_award(p_player_id, 'production_painter'); end if;
+  if v_model_count >= 10 then perform public._grant_award(p_player_id, 'master_artisan'); end if;
+
+  if public._has_3_consecutive_painting_months(p_player_id) then
+    perform public._grant_award(p_player_id, 'the_long_vigil');
+  end if;
+
+  -- Lore writing track (type = 'scribe')
+  select count(*) into v_lore_count
+  from public.submissions
+  where player_id = p_player_id and type = 'scribe' and status = 'approved';
+
+  if v_lore_count >= 1  then perform public._grant_award(p_player_id, 'remembrancer'); end if;
+  if v_lore_count >= 3  then perform public._grant_award(p_player_id, 'chronicler'); end if;
+  if v_lore_count >= 10 then perform public._grant_award(p_player_id, 'master_scribe'); end if;
+
+  -- Lore reading track (type = 'loremaster')
+  select
+    count(*) filter (where type = 'loremaster'),
+    count(*) filter (where type = 'loremaster' and lore_format = 'novel'),
+    count(*) filter (where type = 'loremaster' and lore_format = 'audiobook')
+    into v_loremaster_count, v_novel_count, v_audiobook_count
+  from public.submissions
+  where player_id = p_player_id and status = 'approved';
+
+  if v_novel_count      >= 1   then perform public._grant_award(p_player_id, 'seeker_of_truth'); end if;
+  if v_audiobook_count  >= 1   then perform public._grant_award(p_player_id, 'vox_logged'); end if;
+  if v_loremaster_count >= 15  then perform public._grant_award(p_player_id, 'witness_of_the_word'); end if;
+  if v_loremaster_count >= 100 then perform public._grant_award(p_player_id, 'keeper_of_the_black_library'); end if;
+
+  if public._has_12_consecutive_loremaster_months(p_player_id) then
+    perform public._grant_award(p_player_id, 'eternal_witness');
+  end if;
+
+  -- Conquest: Planetfall
+  if exists (
+    select 1
+    from public.submissions s
+    join public.planets p on p.id = s.target_planet_id
+    where s.player_id = p_player_id
+      and s.status = 'approved'
+      and s.faction_id is not null
+      and p.controlling_faction_id = s.faction_id
+  ) then
+    perform public._grant_award(p_player_id, 'planetfall');
+  end if;
+
+  -- Holdfast
+  if exists (
+    select 1
+    from public.planet_flip_log pfl
+    join public.submissions s
+      on s.target_planet_id = pfl.planet_id
+     and s.faction_id       = pfl.gained_faction_id
+     and s.status            = 'approved'
+     and s.created_at        > pfl.created_at
+    where s.player_id = p_player_id
+  ) then
+    perform public._grant_award(p_player_id, 'holdfast');
+  end if;
+
+  -- World Eater
+  if exists (
+    select 1 from public.planet_flip_log
+    where top_contributor_id = p_player_id
+  ) then
+    perform public._grant_award(p_player_id, 'world_eater');
+  end if;
+
+  -- Crusade Architect
+  if (
+    select count(distinct pfl.planet_id)
+    from public.planet_flip_log pfl
+    where exists (
+      select 1 from public.submissions s
+      where s.player_id        = p_player_id
+        and s.target_planet_id = pfl.planet_id
+        and s.faction_id       = pfl.gained_faction_id
+        and s.status            = 'approved'
+        and s.created_at        <= pfl.created_at
+    )
+  ) >= 3 then
+    perform public._grant_award(p_player_id, 'crusade_architect');
+  end if;
+
+  -- Accept Any Challenge
+  select count(distinct type) into v_distinct_types
+  from public.submissions
+  where player_id = p_player_id and status = 'approved';
+
+  v_total_types := array_length(enum_range(null::public.submission_type), 1);
+
+  if v_distinct_types is not null
+     and v_total_types is not null
+     and v_distinct_types >= v_total_types then
+    perform public._grant_award(p_player_id, 'accept_any_challenge');
+  end if;
+
+  -- Faithful Servant
+  if public._has_12_consecutive_weeks(p_player_id) then
+    perform public._grant_award(p_player_id, 'faithful_servant');
+  end if;
+
+  -- Veteran of the Long War
+  select rnk into v_creation_rank
+  from (
+    select id, dense_rank() over (order by created_at) as rnk
+    from public.profiles
+  ) t
+  where t.id = p_player_id;
+
+  if v_creation_rank is not null and v_creation_rank <= 10 then
+    perform public._grant_award(p_player_id, 'veteran_of_the_long_war');
+  end if;
+end $$;
+
+-- ---------- 7. EXTEND COMPETITIVE EVALUATOR ----------
+-- Adds Astropathic Choir. "Active commander" = any profile with at least one
+-- approved submission of any type. The badge unlocks for every active
+-- commander once a calendar month exists in which all of them logged ≥1
+-- approved loremaster deed. Once earned, the badge is permanent (we don't
+-- delete it if a later month has gaps) — it commemorates a moment.
+create or replace function public.evaluate_competitive_awards()
+returns void
+language plpgsql
+security definer
+as $$
+declare
+  v_warmaster   uuid;
+  v_painter     uuid;
+  v_lorekeeper  uuid;
+  v_global_top  uuid;
+  v_active_count int;
+  v_choir_month date;
+  r record;
+begin
+  -- Warmaster
+  select player_id into v_warmaster
+  from (
+    select player_id, count(*) as cnt
+    from public.submissions
+    where type = 'game' and status = 'approved'
+    group by player_id
+  ) t
+  where cnt >= 20
+  order by cnt desc, player_id asc
+  limit 1;
+
+  delete from public.player_awards pa
+  using public.awards a
+  where pa.award_id = a.id
+    and a.key = 'warmaster'
+    and (v_warmaster is null or pa.player_id <> v_warmaster);
+
+  if v_warmaster is not null then
+    perform public._grant_award(v_warmaster, 'warmaster');
+  end if;
+
+  -- Painting Daemon
+  select player_id into v_painter
+  from (
+    select player_id, count(*) as cnt
+    from public.submissions
+    where type = 'model' and status = 'approved'
+    group by player_id
+  ) t
+  where cnt >= 20
+  order by cnt desc, player_id asc
+  limit 1;
+
+  delete from public.player_awards pa
+  using public.awards a
+  where pa.award_id = a.id
+    and a.key = 'painting_daemon'
+    and (v_painter is null or pa.player_id <> v_painter);
+
+  if v_painter is not null then
+    perform public._grant_award(v_painter, 'painting_daemon');
+  end if;
+
+  -- Keeper of Secrets (writing-track competitive)
+  select player_id into v_lorekeeper
+  from (
+    select player_id, count(*) as cnt
+    from public.submissions
+    where type = 'scribe' and status = 'approved'
+    group by player_id
+  ) t
+  where cnt >= 20
+  order by cnt desc, player_id asc
+  limit 1;
+
+  delete from public.player_awards pa
+  using public.awards a
+  where pa.award_id = a.id
+    and a.key = 'keeper_of_secrets'
+    and (v_lorekeeper is null or pa.player_id <> v_lorekeeper);
+
+  if v_lorekeeper is not null then
+    perform public._grant_award(v_lorekeeper, 'keeper_of_secrets');
+  end if;
+
+  -- First Among Equals
+  select player_id into v_global_top
+  from public.player_totals
+  where total_points >= 50
+  order by total_points desc, player_id asc
+  limit 1;
+
+  delete from public.player_awards pa
+  using public.awards a
+  where pa.award_id = a.id
+    and a.key = 'first_among_equals'
+    and (v_global_top is null or pa.player_id <> v_global_top);
+
+  if v_global_top is not null then
+    perform public._grant_award(v_global_top, 'first_among_equals');
+  end if;
+
+  -- Standard Bearer
+  delete from public.player_awards pa
+  using public.awards a
+  where pa.award_id = a.id
+    and a.key = 'standard_bearer'
+    and pa.player_id not in (
+      select distinct on (faction_id) player_id
+      from public.player_totals
+      where faction_id is not null and total_points >= 30
+      order by faction_id, total_points desc, player_id asc
+    );
+
+  for r in
+    select distinct on (faction_id) player_id
+    from public.player_totals
+    where faction_id is not null and total_points >= 30
+    order by faction_id, total_points desc, player_id asc
+  loop
+    perform public._grant_award(r.player_id, 'standard_bearer');
+  end loop;
+
+  -- Astropathic Choir
+  --
+  -- Find any month in which every active commander logged ≥ 1 approved
+  -- loremaster deed. If such a month exists, grant the badge to all
+  -- commanders who participated in any such month. The badge is sticky:
+  -- we never revoke it.
+  select count(distinct s.player_id) into v_active_count
+  from public.submissions s
+  where s.status = 'approved';
+
+  if v_active_count is not null and v_active_count > 0 then
+    select date_trunc('month', s.created_at)::date into v_choir_month
+    from public.submissions s
+    where s.type = 'loremaster' and s.status = 'approved'
+    group by date_trunc('month', s.created_at)::date
+    having count(distinct s.player_id) >= v_active_count
+    order by date_trunc('month', s.created_at)::date desc
+    limit 1;
+
+    if v_choir_month is not null then
+      for r in
+        select distinct s.player_id
+        from public.submissions s
+        where s.type = 'loremaster'
+          and s.status = 'approved'
+          and date_trunc('month', s.created_at)::date in (
+            select date_trunc('month', s2.created_at)::date
+            from public.submissions s2
+            where s2.type = 'loremaster' and s2.status = 'approved'
+            group by date_trunc('month', s2.created_at)::date
+            having count(distinct s2.player_id) >= v_active_count
+          )
+      loop
+        perform public._grant_award(r.player_id, 'astropathic_choir');
+      end loop;
+    end if;
+  end if;
+end $$;
+
+-- ---------- 8. BACKFILL ----------
+select public.evaluate_player_awards(id) from public.profiles;
+select public.evaluate_competitive_awards();

--- a/supabase/migrations/0011_lore_split_polish.sql
+++ b/supabase/migrations/0011_lore_split_polish.sql
@@ -1,0 +1,259 @@
+-- ============================================================================
+-- 0011_lore_split_polish.sql
+--
+-- Polish pass on top of 0009/0010:
+--
+--   1. Renames the renamed `master_scribe` badge's *display name* from
+--      "Loremaster" to "Master Scribe" so it no longer collides with the
+--      Loremaster submission-type label. Tightens the description and icon.
+--   2. Updates icons on every award that collided with another award or with
+--      a submission-type icon (paintbrush, scroll, open book, eye, classical
+--      building). Every submission-type and award icon is now unique.
+--   3. Tightens descriptions of the three other writing-track badges
+--      (remembrancer, chronicler, keeper_of_secrets) which read "lore
+--      entries" before the split — now ambiguous between writing/reading.
+--   4. Reworks `accept_any_challenge` to count only the four user-facing
+--      submission types (game/model/scribe/loremaster). Bonus is admin-only,
+--      so the original `enum_range`-based threshold made the badge effectively
+--      unattainable without an admin grant. After the lore split the
+--      threshold rose from 4 to 5; this migration anchors it at the four
+--      types a player can actually submit.
+--   5. Backfills `evaluate_player_awards` for every profile so the changed
+--      threshold takes effect immediately and any previously-missed grants
+--      (including Nemesis if it was missed for any reason) are reapplied.
+-- ============================================================================
+
+-- ---------- 1. RENAME MASTER SCRIBE BADGE DISPLAY ----------
+update public.awards
+set name        = 'Master Scribe',
+    description = 'Ten approved chronicles. The archives know your name.',
+    hint        = 'Author ten chronicles to fill the archive.',
+    icon        = '✒️'
+where key = 'master_scribe';
+
+-- ---------- 2. RESOLVE ICON COLLISIONS ----------
+-- brush_initiate (🖌) collided with the `painted` submission type.
+update public.awards set icon = '🖍' where key = 'brush_initiate';
+
+-- remembrancer (📖) collided with the `loremaster` submission type.
+update public.awards set icon = '🪶' where key = 'remembrancer';
+
+-- chronicler (📜) collided with the `scribe` submission type.
+update public.awards set icon = '📝' where key = 'chronicler';
+
+-- keeper_of_secrets (👁) collided with eternal_witness (also 👁).
+update public.awards set icon = '🔮' where key = 'keeper_of_secrets';
+
+-- ---------- 3. CLARIFY WRITING-TRACK DESCRIPTIONS ----------
+-- After the split, "lore entries" is ambiguous. These three are all
+-- writing-track; the new copy says so explicitly.
+update public.awards
+set description = 'Your first approved chronicle.',
+    hint        = 'Set quill to parchment for the first time.'
+where key = 'remembrancer';
+
+update public.awards
+set description = 'Three approved chronicles.',
+    hint        = 'Three tales recorded for posterity.'
+where key = 'chronicler';
+
+update public.awards
+set description = 'Twenty chronicles, and none more learned than you.',
+    hint        = 'Hold more knowledge than any other scholar.'
+where key = 'keeper_of_secrets';
+
+-- ---------- 4. ACCEPT ANY CHALLENGE: 4 user-facing types ----------
+-- Replace the per-player evaluator. The only behavioural change vs 0010 is
+-- the Accept Any Challenge block: count distinct types excluding `bonus`,
+-- threshold of 4. Everything else is identical to 0010.
+create or replace function public.evaluate_player_awards(p_player_id uuid)
+returns void
+language plpgsql
+security definer
+as $$
+declare
+  v_game_count        int;
+  v_model_count       int;
+  v_lore_count        int;
+  v_loremaster_count  int;
+  v_novel_count       int;
+  v_audiobook_count   int;
+  v_max_streak        int;
+  v_distinct_types    int;
+  v_creation_rank     int;
+begin
+  if p_player_id is null then return; end if;
+
+  -- Combat: total approved games
+  select count(*) into v_game_count
+  from public.submissions
+  where player_id = p_player_id and type = 'game' and status = 'approved';
+
+  if v_game_count >= 1  then perform public._grant_award(p_player_id, 'first_blood'); end if;
+  if v_game_count >= 3  then perform public._grant_award(p_player_id, 'veteran'); end if;
+  if v_game_count >= 10 then perform public._grant_award(p_player_id, 'honored_of_the_chapter'); end if;
+
+  -- Win streak
+  v_max_streak := public._max_win_streak(p_player_id);
+  if v_max_streak >= 3  then perform public._grant_award(p_player_id, 'double_tap'); end if;
+  if v_max_streak >= 5  then perform public._grant_award(p_player_id, 'overkill'); end if;
+  if v_max_streak >= 10 then perform public._grant_award(p_player_id, 'exterminatus'); end if;
+
+  -- Nemesis
+  if exists (
+    select 1
+    from public.submissions
+    where player_id = p_player_id
+      and status = 'approved'
+      and type = 'game'
+      and result = 'win'
+      and adversary_user_id is not null
+    group by adversary_user_id
+    having count(*) >= 3
+  ) then
+    perform public._grant_award(p_player_id, 'nemesis');
+  end if;
+
+  -- David
+  if exists (
+    select 1
+    from public.submissions s
+    join public.elo_config ec on ec.game_system_id = s.game_system_id
+    where s.player_id = p_player_id
+      and s.status = 'approved'
+      and s.type = 'game'
+      and s.result = 'win'
+      and s.adversary_user_id is not null
+      and s.elo_delta is not null
+      and s.elo_delta::numeric > (ec.k_factor::numeric / 2)
+  ) then
+    perform public._grant_award(p_player_id, 'david');
+  end if;
+
+  -- Painting
+  select count(*) into v_model_count
+  from public.submissions
+  where player_id = p_player_id and type = 'model' and status = 'approved';
+
+  if v_model_count >= 1  then perform public._grant_award(p_player_id, 'brush_initiate'); end if;
+  if v_model_count >= 3  then perform public._grant_award(p_player_id, 'production_painter'); end if;
+  if v_model_count >= 10 then perform public._grant_award(p_player_id, 'master_artisan'); end if;
+
+  if public._has_3_consecutive_painting_months(p_player_id) then
+    perform public._grant_award(p_player_id, 'the_long_vigil');
+  end if;
+
+  -- Lore writing track
+  select count(*) into v_lore_count
+  from public.submissions
+  where player_id = p_player_id and type = 'scribe' and status = 'approved';
+
+  if v_lore_count >= 1  then perform public._grant_award(p_player_id, 'remembrancer'); end if;
+  if v_lore_count >= 3  then perform public._grant_award(p_player_id, 'chronicler'); end if;
+  if v_lore_count >= 10 then perform public._grant_award(p_player_id, 'master_scribe'); end if;
+
+  -- Lore reading track
+  select
+    count(*) filter (where type = 'loremaster'),
+    count(*) filter (where type = 'loremaster' and lore_format = 'novel'),
+    count(*) filter (where type = 'loremaster' and lore_format = 'audiobook')
+    into v_loremaster_count, v_novel_count, v_audiobook_count
+  from public.submissions
+  where player_id = p_player_id and status = 'approved';
+
+  if v_novel_count      >= 1   then perform public._grant_award(p_player_id, 'seeker_of_truth'); end if;
+  if v_audiobook_count  >= 1   then perform public._grant_award(p_player_id, 'vox_logged'); end if;
+  if v_loremaster_count >= 15  then perform public._grant_award(p_player_id, 'witness_of_the_word'); end if;
+  if v_loremaster_count >= 100 then perform public._grant_award(p_player_id, 'keeper_of_the_black_library'); end if;
+
+  if public._has_12_consecutive_loremaster_months(p_player_id) then
+    perform public._grant_award(p_player_id, 'eternal_witness');
+  end if;
+
+  -- Conquest: Planetfall
+  if exists (
+    select 1
+    from public.submissions s
+    join public.planets p on p.id = s.target_planet_id
+    where s.player_id = p_player_id
+      and s.status = 'approved'
+      and s.faction_id is not null
+      and p.controlling_faction_id = s.faction_id
+  ) then
+    perform public._grant_award(p_player_id, 'planetfall');
+  end if;
+
+  -- Holdfast
+  if exists (
+    select 1
+    from public.planet_flip_log pfl
+    join public.submissions s
+      on s.target_planet_id = pfl.planet_id
+     and s.faction_id       = pfl.gained_faction_id
+     and s.status            = 'approved'
+     and s.created_at        > pfl.created_at
+    where s.player_id = p_player_id
+  ) then
+    perform public._grant_award(p_player_id, 'holdfast');
+  end if;
+
+  -- World Eater
+  if exists (
+    select 1 from public.planet_flip_log
+    where top_contributor_id = p_player_id
+  ) then
+    perform public._grant_award(p_player_id, 'world_eater');
+  end if;
+
+  -- Crusade Architect
+  if (
+    select count(distinct pfl.planet_id)
+    from public.planet_flip_log pfl
+    where exists (
+      select 1 from public.submissions s
+      where s.player_id        = p_player_id
+        and s.target_planet_id = pfl.planet_id
+        and s.faction_id       = pfl.gained_faction_id
+        and s.status            = 'approved'
+        and s.created_at        <= pfl.created_at
+    )
+  ) >= 3 then
+    perform public._grant_award(p_player_id, 'crusade_architect');
+  end if;
+
+  -- Accept Any Challenge: one approved submission of every USER-FACING type.
+  -- Bonus is admin-only and is excluded from the requirement so the badge is
+  -- attainable through normal play. Threshold is the fixed count of
+  -- player-submittable types (game, model, scribe, loremaster) = 4.
+  select count(distinct type) into v_distinct_types
+  from public.submissions
+  where player_id = p_player_id
+    and status = 'approved'
+    and type in ('game','model','scribe','loremaster');
+
+  if v_distinct_types is not null and v_distinct_types >= 4 then
+    perform public._grant_award(p_player_id, 'accept_any_challenge');
+  end if;
+
+  -- Faithful Servant
+  if public._has_12_consecutive_weeks(p_player_id) then
+    perform public._grant_award(p_player_id, 'faithful_servant');
+  end if;
+
+  -- Veteran of the Long War
+  select rnk into v_creation_rank
+  from (
+    select id, dense_rank() over (order by created_at) as rnk
+    from public.profiles
+  ) t
+  where t.id = p_player_id;
+
+  if v_creation_rank is not null and v_creation_rank <= 10 then
+    perform public._grant_award(p_player_id, 'veteran_of_the_long_war');
+  end if;
+end $$;
+
+-- ---------- 5. BACKFILL ----------
+-- Re-evaluate every player so the new accept_any_challenge threshold and any
+-- previously-missed grants (e.g. Nemesis) are applied immediately.
+select public.evaluate_player_awards(id) from public.profiles;


### PR DESCRIPTION
## Summary
- Splits the existing `lore` submission type into `scribe` (writing) and `loremaster` (reading/listening per issue #31). Loremaster captures title, format (novel/audiobook), 1–5 star rating, and a 50–500 char reflection — fixed 1 glory.
- Adds six new awards: Seeker of Truth, Vox-Logged, Witness of the Word, Keeper of the Black Library, Astropathic Choir, The Eternal Witness. The existing "Loremaster" badge is renamed to "Master Scribe" so it no longer collides with the new submission-type label; player-earned rows are preserved (badge id is unchanged).
- Polish pass: every submission-type and award icon is now unique (five collisions resolved); Accept Any Challenge counts only the four user-facing types (bonus is admin-only); writing-track badge descriptions clarified after the split; leaderboard gains a parallel "Lore Read" column alongside "Tales".

This branch also carries the unmerged #26 awards phase 2 commit (`0e7d784`) — lore-split builds directly on the phase-2 evaluator and flip log, so they ship together.

## Test plan
- [x] Apply migrations 0009 → 0010 → 0011 in the Supabase SQL editor (each as a separate transaction; PG won't allow new enum values to be referenced in the transaction that adds them)
- [x] Confirm `submissions.type='lore'` rows automatically became `'scribe'` and the count matches pre-migration
- [x] Submit a Loremaster deed (novel, 4 stars, 200-char reflection) — confirm it lands in admin queue with format pill + star row
- [x] Approve it; confirm Seeker of Truth fires and dashboard `loremaster` counter increments
- [x] Submit an audiobook; approve; confirm Vox-Logged fires
- [x] Submit a Scribe entry — confirm it counts toward Remembrancer/Chronicler/Master Scribe, leaderboard "Tales" column ticks up
- [x] Leaderboard shows both "Tales" and "Lore Read" columns at md+ widths
- [x] No two submission-type/award icons render the same glyph
- [x] Accept Any Challenge requires only 4 types (game/model/scribe/loremaster); bonus no longer counted

🤖 Generated with [Claude Code](https://claude.com/claude-code)