### PR TITLE
Add Season Administration: snapshot export and campaign clear

### DIFF
--- a/app/admin/AdminSeason.tsx
+++ b/app/admin/AdminSeason.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+
+const EXPORT_TABLES = [
+  "profiles",
+  "factions",
+  "planets",
+  "planet_points",
+  "planet_flip_log",
+  "submissions",
+  "awards",
+  "player_awards",
+  "elo_ratings",
+  "elo_config",
+  "player_factions",
+  "game_systems",
+  "point_schemes",
+  "video_game_titles",
+  "planet_game_systems",
+] as const;
+
+const EXPORT_VIEWS = ["faction_totals", "player_totals"] as const;
+
+const CONFIRM_WORDS = ["CLEAR", "DELETE"];
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err && typeof err === "object") {
+    const o = err as Record<string, unknown>;
+    const parts = [o.message, o.details, o.hint, o.code]
+      .filter((x): x is string => typeof x === "string" && x.length > 0);
+    if (parts.length > 0) return parts.join(" — ");
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
+
+export function AdminSeason() {
+  const router = useRouter();
+
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const [clearing, setClearing] = useState(false);
+  const [clearError, setClearError] = useState<string | null>(null);
+  const [clearedAt, setClearedAt] = useState<string | null>(null);
+
+  async function exportCampaign() {
+    setExporting(true);
+    setExportError(null);
+    try {
+      const supabase = createClient();
+      const data: Record<string, unknown> = {
+        exported_at: new Date().toISOString(),
+        schema_version: "0012",
+      };
+
+      for (const table of EXPORT_TABLES) {
+        const { data: rows, error } = await supabase.from(table).select("*");
+        if (error) throw new Error(`${table}: ${error.message}`);
+        data[table] = rows ?? [];
+      }
+      for (const view of EXPORT_VIEWS) {
+        const { data: rows, error } = await supabase.from(view).select("*");
+        if (error) throw new Error(`${view}: ${error.message}`);
+        data[view] = rows ?? [];
+      }
+
+      const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `crusade-snapshot-${stamp}.json`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setExportError(describeError(err));
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  function openConfirm() {
+    setConfirmText("");
+    setClearError(null);
+    setConfirmOpen(true);
+  }
+
+  function cancelConfirm() {
+    if (clearing) return;
+    setConfirmOpen(false);
+    setConfirmText("");
+    setClearError(null);
+  }
+
+  const confirmIsValid = CONFIRM_WORDS.includes(
+    confirmText.trim().toUpperCase()
+  );
+
+  async function clearCampaign() {
+    if (!confirmIsValid) return;
+    setClearing(true);
+    setClearError(null);
+    try {
+      const supabase = createClient();
+      const { error } = await supabase.rpc("admin_clear_campaign");
+      if (error) throw error;
+      setConfirmOpen(false);
+      setConfirmText("");
+      setClearedAt(new Date().toISOString());
+      router.refresh();
+    } catch (err) {
+      setClearError(describeError(err));
+    } finally {
+      setClearing(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="card p-6 space-y-4">
+        <div>
+          <div className="font-display text-parchment">
+            Export Campaign Snapshot
+          </div>
+          <p className="text-sm text-parchment-dim font-body italic mt-1">
+            Download a JSON file with every profile, deed, award, planet
+            claim, ELO rating and leaderboard total. Run this before clearing
+            so the season can be remembered in the histories.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            onClick={exportCampaign}
+            disabled={exporting}
+            className="btn-primary disabled:opacity-50"
+          >
+            {exporting ? "Compiling archives…" : "Download Snapshot"}
+          </button>
+          {exportError && (
+            <span className="text-sm text-blood">{exportError}</span>
+          )}
+        </div>
+      </div>
+
+      <div className="card p-6 space-y-4 border border-blood/40">
+        <div>
+          <div className="font-display text-parchment">
+            Clear Campaign for New Season
+          </div>
+          <p className="text-sm text-parchment-dim font-body italic mt-1">
+            Wipes all submissions, awards, planet claims, ELO ratings and the
+            planet flip log. Profiles, factions, planets, the awards
+            catalogue and game-system configuration are preserved.{" "}
+            <span className="text-blood not-italic">This cannot be undone.</span>
+          </p>
+        </div>
+
+        {!confirmOpen ? (
+          <div className="flex flex-wrap items-center gap-3">
+            <button onClick={openConfirm} className="btn-danger">
+              Clear Campaign…
+            </button>
+            {clearedAt && (
+              <span className="text-sm text-parchment-dim italic">
+                Last cleared {new Date(clearedAt).toLocaleString()}.
+              </span>
+            )}
+          </div>
+        ) : (
+          <div className="rounded border border-blood/60 bg-blood/5 p-4 space-y-3">
+            <div className="text-sm text-parchment">
+              To confirm, type{" "}
+              <span className="font-mono text-blood">CLEAR</span> or{" "}
+              <span className="font-mono text-blood">DELETE</span> below.
+            </div>
+            <input
+              type="text"
+              autoFocus
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder="Type CLEAR or DELETE"
+              className="input w-full"
+              disabled={clearing}
+            />
+            {clearError && (
+              <div className="text-sm text-blood">{clearError}</div>
+            )}
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={cancelConfirm}
+                disabled={clearing}
+                className="btn-ghost text-sm"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={clearCampaign}
+                disabled={!confirmIsValid || clearing}
+                className="btn-danger text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {clearing ? "Wiping the slate…" : "Confirm Clear"}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { AdminQueue } from "./AdminQueue";
 import { AdminPlanets } from "./AdminPlanets";
 import { AdminFactions } from "./AdminFactions";
+import { AdminSeason } from "./AdminSeason";
 import type {
   Submission,
   Faction,
@@ -97,6 +98,13 @@ export default async function AdminPage() {
           FACTIONS
         </h2>
         <AdminFactions factions={(factions ?? []) as Faction[]} />
+      </section>
+
+      <section>
+        <h2 className="font-display text-2xl tracking-widest text-parchment mb-4">
+          SEASON ADMINISTRATION
+        </h2>
+        <AdminSeason />
       </section>
     </div>
   );

--- a/scripts/recap.mjs
+++ b/scripts/recap.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+// Usage: node scripts/recap.mjs path/to/crusade-snapshot-*.json > recap.md
+//
+// Reads a snapshot exported from the admin panel's Season Administration
+// section and prints a markdown campaign recap to stdout.
+
+import { readFileSync } from "node:fs";
+import { argv, exit } from "node:process";
+
+const path = argv[2];
+if (!path) {
+  console.error("usage: node scripts/recap.mjs <snapshot.json>");
+  exit(1);
+}
+
+const snap = JSON.parse(readFileSync(path, "utf8"));
+
+const factions          = snap.factions          ?? [];
+const profiles          = snap.profiles          ?? [];
+const planets           = snap.planets           ?? [];
+const submissions       = snap.submissions       ?? [];
+const flips             = snap.planet_flip_log   ?? [];
+const awards            = snap.awards            ?? [];
+const playerAwards      = snap.player_awards     ?? [];
+const factionTotals     = snap.faction_totals    ?? [];
+const playerTotals      = snap.player_totals     ?? [];
+const eloRatings        = snap.elo_ratings       ?? [];
+const planetPoints      = snap.planet_points     ?? [];
+
+const factionById = new Map(factions.map((f) => [f.id, f]));
+const profileById = new Map(profiles.map((p) => [p.id, p]));
+const awardById   = new Map(awards.map((a) => [a.id, a]));
+const planetById  = new Map(planets.map((p) => [p.id, p]));
+
+const out = [];
+const w = (line = "") => out.push(line);
+
+const fmtDate = (iso) =>
+  iso ? new Date(iso).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" }) : "—";
+
+const fmtDateTime = (iso) =>
+  iso ? new Date(iso).toLocaleString() : "—";
+
+// ---------- Header ----------
+const exportedAt = snap.exported_at ?? new Date().toISOString();
+w(`# Crusade Recap`);
+w();
+w(`Snapshot taken **${fmtDateTime(exportedAt)}**.`);
+w();
+
+// ---------- By the Numbers ----------
+const approved = submissions.filter((s) => s.status === "approved");
+const counts = {
+  game:       approved.filter((s) => s.type === "game").length,
+  model:      approved.filter((s) => s.type === "model").length,
+  scribe:     approved.filter((s) => s.type === "scribe" || s.type === "lore").length,
+  loremaster: approved.filter((s) => s.type === "loremaster").length,
+  bonus:      approved.filter((s) => s.type === "bonus").length,
+};
+const totalPoints = approved.reduce((acc, s) => acc + (s.points ?? 0), 0);
+
+w(`## By the Numbers`);
+w();
+w(`- **${profiles.length}** commanders enlisted`);
+w(`- **${factions.length}** factions on the field`);
+w(`- **${approved.length}** approved deeds totalling **${totalPoints}** glory`);
+w(`- ${counts.game} battles · ${counts.model} models · ${counts.scribe} chronicles · ${counts.loremaster} lore-readings · ${counts.bonus} bonus deeds`);
+w(`- **${flips.length}** planet flips logged`);
+w();
+
+// ---------- Faction standings ----------
+w(`## Final Faction Standings`);
+w();
+const factionRanked = [...factionTotals].sort(
+  (a, b) => (b.total_points ?? 0) - (a.total_points ?? 0)
+);
+if (factionRanked.length === 0) {
+  w(`_No faction data._`);
+} else {
+  w(`| # | Faction | Glory | Wins | Models | Lore | Worlds |`);
+  w(`|---|---------|------:|-----:|-------:|-----:|-------:|`);
+  factionRanked.forEach((f, i) => {
+    w(
+      `| ${i + 1} | ${f.faction_name} | ${f.total_points ?? 0} | ${f.wins ?? 0} | ${f.models_painted ?? 0} | ${f.lore_submitted ?? f.lore_written ?? 0} | ${f.planets_controlled ?? 0} |`
+    );
+  });
+}
+w();
+
+// ---------- Player standings ----------
+w(`## Final Commander Standings`);
+w();
+const playerRanked = [...playerTotals]
+  .filter((p) => (p.approved_count ?? 0) > 0 || (p.total_points ?? 0) > 0)
+  .sort((a, b) => (b.total_points ?? 0) - (a.total_points ?? 0));
+if (playerRanked.length === 0) {
+  w(`_No commander data._`);
+} else {
+  w(`| # | Commander | Faction | Glory | Approved Deeds |`);
+  w(`|---|-----------|---------|------:|---------------:|`);
+  playerRanked.forEach((p, i) => {
+    w(
+      `| ${i + 1} | ${p.display_name ?? "—"} | ${p.faction_name ?? "—"} | ${p.total_points ?? 0} | ${p.approved_count ?? 0} |`
+    );
+  });
+}
+w();
+
+// ---------- Worlds ----------
+w(`## Worlds at Season's End`);
+w();
+const planetsSorted = [...planets].sort((a, b) => a.name.localeCompare(b.name));
+if (planetsSorted.length === 0) {
+  w(`_No planets._`);
+} else {
+  w(`| Planet | Controller | Threshold | Claimed | Top Contender |`);
+  w(`|--------|------------|----------:|---------|---------------|`);
+  planetsSorted.forEach((p) => {
+    const controller = p.controlling_faction_id
+      ? factionById.get(p.controlling_faction_id)?.name ?? "—"
+      : "Contested";
+    const top = planetPoints
+      .filter((pp) => pp.planet_id === p.id)
+      .sort((a, b) => (b.points ?? 0) - (a.points ?? 0))[0];
+    const topLabel = top
+      ? `${factionById.get(top.faction_id)?.name ?? "?"} (${top.points})`
+      : "—";
+    w(
+      `| ${p.name} | ${controller} | ${p.threshold} | ${fmtDate(p.claimed_at)} | ${topLabel} |`
+    );
+  });
+}
+w();
+
+// ---------- Planet flip log ----------
+if (flips.length > 0) {
+  w(`## Planet Flip Chronicle`);
+  w();
+  const ordered = [...flips].sort(
+    (a, b) => new Date(a.created_at) - new Date(b.created_at)
+  );
+  for (const f of ordered) {
+    const planet  = planetById.get(f.planet_id)?.name ?? "?";
+    const gained  = factionById.get(f.gained_faction_id)?.name ?? "?";
+    const lost    = f.lost_faction_id ? factionById.get(f.lost_faction_id)?.name ?? "?" : null;
+    const top     = f.top_contributor_id ? profileById.get(f.top_contributor_id)?.display_name ?? "?" : null;
+    const stem    = lost
+      ? `**${gained}** wrested **${planet}** from **${lost}**`
+      : `**${gained}** raised the banner over **${planet}**`;
+    const tail    = top ? ` — top contributor: *${top}* (${f.points_at_flip ?? 0} glory at flip)` : "";
+    w(`- ${fmtDate(f.created_at)} — ${stem}${tail}.`);
+  }
+  w();
+}
+
+// ---------- Honours Roll ----------
+w(`## Honours Roll`);
+w();
+const awardsByPlayer = new Map();
+for (const pa of playerAwards) {
+  const list = awardsByPlayer.get(pa.player_id) ?? [];
+  list.push(pa);
+  awardsByPlayer.set(pa.player_id, list);
+}
+const honoured = [...awardsByPlayer.entries()]
+  .map(([pid, list]) => ({
+    player: profileById.get(pid),
+    awards: list
+      .map((pa) => awardById.get(pa.award_id))
+      .filter(Boolean)
+      .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0)),
+  }))
+  .filter((h) => h.player)
+  .sort((a, b) => b.awards.length - a.awards.length);
+
+if (honoured.length === 0) {
+  w(`_No honours awarded._`);
+} else {
+  for (const { player, awards } of honoured) {
+    w(`### ${player.display_name} — ${awards.length} honour${awards.length === 1 ? "" : "s"}`);
+    for (const a of awards) {
+      w(`- ${a.icon} **${a.name}** — ${a.description}`);
+    }
+    w();
+  }
+}
+
+// ---------- ELO Top 10 ----------
+if (eloRatings.length > 0) {
+  w(`## Sanctioned Duel Ratings (Top 10)`);
+  w();
+  const topElo = [...eloRatings]
+    .filter((r) => (r.games_played ?? 0) > 0)
+    .sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0))
+    .slice(0, 10);
+  if (topElo.length === 0) {
+    w(`_No rated games._`);
+  } else {
+    w(`| # | Commander | Faction | Rating | W-L-D |`);
+    w(`|---|-----------|---------|-------:|-------|`);
+    topElo.forEach((r, i) => {
+      const player = profileById.get(r.user_id)?.display_name ?? "—";
+      const faction = factionById.get(r.faction_id)?.name ?? "—";
+      w(
+        `| ${i + 1} | ${player} | ${faction} | ${r.rating} | ${r.wins ?? 0}-${r.losses ?? 0}-${r.draws ?? 0} |`
+      );
+    });
+  }
+  w();
+}
+
+process.stdout.write(out.join("\n") + "\n");

--- a/supabase/migrations/0012_season_admin.sql
+++ b/supabase/migrations/0012_season_admin.sql
@@ -1,0 +1,51 @@
+-- ============================================================================
+-- 0012_season_admin.sql
+--
+-- Season Administration: a single SECURITY DEFINER RPC that wipes all
+-- campaign-generated data so a fresh season can begin without dropping users
+-- or rebuilding the catalogue.
+--
+--   * Keeps: profiles, factions, planets (rows themselves), awards catalogue,
+--            game_systems, point_schemes, video_game_titles, planet_game_systems,
+--            player_factions, elo_config.
+--   * Wipes: submissions, planet_points, planet_flip_log, player_awards,
+--            elo_ratings.
+--   * Resets: planets.controlling_faction_id = null, planets.claimed_at = null.
+--
+-- Caller must be an admin (`profiles.is_admin = true`); checked inside the
+-- function so the SECURITY DEFINER context cannot be abused.
+-- ============================================================================
+
+create or replace function public.admin_clear_campaign()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not exists (
+    select 1 from public.profiles
+    where id = auth.uid() and is_admin = true
+  ) then
+    raise exception 'Only administrators may clear the campaign';
+  end if;
+
+  -- Order matters only for FKs without cascade; most of these cascade from
+  -- submissions/planets, but explicit deletes keep intent obvious.
+  -- `where true` satisfies pg_safeupdate, which Supabase loads for API roles
+  -- and which rejects bare DELETE/UPDATE even inside SECURITY DEFINER bodies.
+  delete from public.elo_ratings      where true;
+  delete from public.planet_flip_log  where true;
+  delete from public.player_awards    where true;
+  delete from public.planet_points    where true;
+  delete from public.submissions      where true;
+
+  update public.planets
+  set controlling_faction_id = null,
+      claimed_at             = null
+  where controlling_faction_id is not null
+     or claimed_at is not null;
+end $$;
+
+revoke all on function public.admin_clear_campaign() from public;
+grant execute on function public.admin_clear_campaign() to authenticated;


### PR DESCRIPTION
## Summary
- New admin "Season Administration" section with two actions: download a JSON snapshot of the current campaign, and clear the campaign for a fresh season.
- Snapshot export pulls every campaign-relevant table plus the `faction_totals` / `player_totals` views and triggers a `crusade-snapshot-<timestamp>.json` download. Designed as the source for a future historical page.
- Clear wipes `submissions`, `planet_points`, `planet_flip_log`, `player_awards`, `elo_ratings` and resets each planet's controller / claim date — profiles, factions, planet rows, the awards catalogue and configuration tables are preserved. Confirm button is disabled until the admin types `CLEAR` or `DELETE`.
- Migration `0012_season_admin.sql` adds `admin_clear_campaign()`, a SECURITY DEFINER function with an inline `is_admin` check. Deletes carry `where true` predicates so `pg_safeupdate` (loaded for API roles) doesn't reject them.
- Bundles `scripts/recap.mjs` — a zero-dependency Node script that reads a snapshot and prints a markdown recap (final standings, world control, flip chronicle, honours roll, top ELO).

## Test plan
- [x] Apply migration locally (`supabase migration up` or re-run `0012_season_admin.sql`).
- [x] Visit `/admin` as an admin and confirm the new "SEASON ADMINISTRATION" section renders below "FACTIONS".
- [x] Click **Download Snapshot** and verify a JSON file downloads with non-empty `profiles`, `submissions`, `planets`, `planet_flip_log`, `player_awards`, `faction_totals`, `player_totals`, etc.
- [x] Run `node scripts/recap.mjs <snapshot.json> > recap.md` and verify the markdown sections render the campaign's final state.
- [x] Click **Clear Campaign…**, confirm the failsafe panel appears, the confirm button stays disabled until `CLEAR` or `DELETE` is typed (case-insensitive), and that on confirm all relevant tables are emptied and planets show as Contested.
- [x] Verify a non-admin (or signed-out) caller of `admin_clear_campaign()` is rejected by the inline check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)