### PR TITLE
Fix #38: award threshold off-by-one on first approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,14 @@ You'll need free accounts on **Supabase**, **Vercel**, and **Cloudinary**, plus 
 
 ### 2. Run the database setup
 
-The schema is split into two SQL files because PostgreSQL forbids referencing a newly added enum value in the same transaction that adds it. Run them in order:
+The schema is split into SQL files because PostgreSQL forbids referencing a newly added enum value in the same transaction that adds it. Run them in order:
 
 1. In your Supabase project, open **SQL Editor → New query**.
 2. Open `supabase/migrations/0001_schema.sql` from this repo, paste the entire contents into the editor, and click **Run**. You should see "Success. No rows returned." This creates every table, view, trigger, RLS policy, storage bucket, the awards catalogue, the five seeded game systems, and seed factions/planets.
 3. Open a fresh **New query**, paste the contents of `supabase/migrations/0002_features.sql`, and **Run**. This adds the loremaster reading-track features and Season Administration RPC.
+4. Open a fresh **New query**, paste the contents of `supabase/migrations/0003_fix_award_evaluation_timing.sql`, and **Run**. This fixes an off-by-one in award evaluation so threshold-based badges (First Blood, Brush Initiate, etc.) fire on the first qualifying approval rather than the second.
 
-Both files are idempotent (they use `if not exists` / `on conflict do update`), so you can safely re-run them.
+All files are idempotent (they use `if not exists` / `on conflict do update` / `create or replace`), so you can safely re-run them.
 
 ### 3. Set up Cloudinary (image hosting)
 
@@ -208,6 +209,7 @@ lib/
 supabase/migrations/
   0001_schema.sql                         # Tables, RLS, triggers, seed data, awards catalogue
   0002_features.sql                       # Loremaster reading-track + season admin RPC
+  0003_fix_award_evaluation_timing.sql    # AFTER-trigger pass so first-approval badges fire
 middleware.ts                             # Session refresh on every request
 ```
 

--- a/supabase/migrations/0003_fix_award_evaluation_timing.sql
+++ b/supabase/migrations/0003_fix_award_evaluation_timing.sql
@@ -1,0 +1,66 @@
+-- ============================================================================
+-- 0003_fix_award_evaluation_timing.sql
+--
+-- Fixes #38: First Blood, Brush Initiate, and other threshold-based awards
+-- only granted on the SECOND qualifying approval rather than the first.
+--
+-- Root cause
+-- ----------
+-- `trg_award_points` is a BEFORE UPDATE trigger on `public.submissions`. When
+-- the trigger fires on a status flip pending → approved, the row currently
+-- being approved has not yet been written to the table. The evaluator then
+-- runs `select count(*) from submissions where status = 'approved'`, and the
+-- count excludes the row in flight. So:
+--   * 1st qualifying approval: count = 0 → no badge.
+--   * 2nd qualifying approval: count = 1 → first_blood / brush_initiate fire,
+--     but they reflect the previously-approved submission, not the new one.
+-- The same off-by-one affects every threshold check (veteran ≥ 3, master_*
+-- ≥ 10, warmaster ≥ 20, etc.).
+--
+-- Fix
+-- ---
+-- Add an AFTER UPDATE trigger that re-runs the per-player and competitive
+-- evaluators once the approved row is visible. `_grant_award` is idempotent
+-- (`on conflict do nothing`), so the existing BEFORE-trigger evaluator calls
+-- remain harmless — they grant whatever they can with the off-by-one count,
+-- and the AFTER pass picks up anything they missed.
+--
+-- Mirror submissions are inserted directly with status = 'approved', so they
+-- never fire either trigger; the original-side evaluator pass already covers
+-- the adversary explicitly, so nothing else needs to change.
+--
+-- A backfill at the end re-evaluates every existing player so any badges
+-- previously missed because of this bug are granted retroactively.
+-- ============================================================================
+
+create or replace function public.evaluate_awards_after_approval()
+returns trigger
+language plpgsql
+security definer
+as $$
+begin
+  if new.mirror_of is not null then
+    return null;
+  end if;
+
+  if new.status = 'approved'
+     and (old.status is null or old.status <> 'approved') then
+    perform public.evaluate_player_awards(new.player_id);
+    if new.adversary_user_id is not null then
+      perform public.evaluate_player_awards(new.adversary_user_id);
+    end if;
+    perform public.evaluate_competitive_awards();
+  end if;
+
+  return null;
+end $$;
+
+drop trigger if exists trg_evaluate_awards_after on public.submissions;
+create trigger trg_evaluate_awards_after
+after update on public.submissions
+for each row execute function public.evaluate_awards_after_approval();
+
+-- Backfill: re-evaluate every player so badges previously missed because of
+-- the off-by-one are granted retroactively.
+select public.evaluate_player_awards(id) from public.profiles;
+select public.evaluate_competitive_awards();


### PR DESCRIPTION
## Summary
- `trg_award_points` is a `BEFORE UPDATE` trigger, so when status flips `pending → approved` the row in flight is not yet visible to the evaluator's `count(*) where status = 'approved'` queries. First Blood, Brush Initiate, Veteran, Master Artisan, Warmaster, and every other threshold-based award therefore missed the first qualifying approval and only fired on the next one.
- New migration `0003_fix_award_evaluation_timing.sql` adds an `AFTER UPDATE` trigger that re-runs the per-player and competitive evaluators once the approved row is visible. `_grant_award` is idempotent (`on conflict do nothing`), so the existing BEFORE-trigger evaluator calls remain harmless. A backfill re-evaluates every existing player to grant any badges previously missed.
- README updated with the new migration step.

Fixes #38.

## Test plan
- [ ] Run `0003_fix_award_evaluation_timing.sql` against a Supabase project and confirm "Success. No rows returned."
- [ ] On a fresh-ish player, approve their first `game` submission and verify First Blood is granted on that approval (not the second).
- [ ] Approve a first `model` submission and verify Brush Initiate fires on the first approval.
- [ ] Approve a first `scribe` submission → Remembrancer fires.
- [ ] Approve a first `loremaster` (novel) submission → Seeker of Truth fires; audiobook → Vox-Logged.
- [ ] Confirm pre-existing players who should have qualified now show the missed badges (granted by the backfill).
- [ ] Re-run the migration and confirm it is idempotent (no duplicate `player_awards`, trigger is replaced not duplicated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)