### PR TITLE
Fix #41, #40: VLW on profile insert; painted terrain preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The schema is split into SQL files because PostgreSQL forbids referencing a newl
 2. Open `supabase/migrations/0001_schema.sql` from this repo, paste the entire contents into the editor, and click **Run**. You should see "Success. No rows returned." This creates every table, view, trigger, RLS policy, storage bucket, the awards catalogue, the five seeded game systems, and seed factions/planets.
 3. Open a fresh **New query**, paste the contents of `supabase/migrations/0002_features.sql`, and **Run**. This adds the loremaster reading-track features and Season Administration RPC.
 4. Open a fresh **New query**, paste the contents of `supabase/migrations/0003_fix_award_evaluation_timing.sql`, and **Run**. This fixes an off-by-one in award evaluation so threshold-based badges (First Blood, Brush Initiate, etc.) fire on the first qualifying approval rather than the second.
+5. Open a fresh **New query**, paste the contents of `supabase/migrations/0004_vlw_on_profile_insert.sql`, and **Run**. This grants Veteran of the Long War at account-creation time (instead of waiting for a first approval) and backfills the badge for the first 10 existing profiles.
 
 All files are idempotent (they use `if not exists` / `on conflict do update` / `create or replace`), so you can safely re-run them.
 

--- a/app/submit/SubmitPageClient.tsx
+++ b/app/submit/SubmitPageClient.tsx
@@ -112,9 +112,9 @@ function SimpleSubmitForm({
   const [description, setDescription] = useState('');
   const [imageUrl, setImageUrl] = useState('');
   const [imageFile, setImageFile] = useState<File | null>(null);
-  const [points, setPoints] = useState<number>(
-    kind === 'painted' ? POINT_PRESETS.model[0].value : POINT_PRESETS.scribe[0].value,
-  );
+  const initialPreset = kind === 'painted' ? POINT_PRESETS.model[0] : POINT_PRESETS.scribe[0];
+  const [points, setPoints] = useState<number>(initialPreset.value);
+  const [presetLabel, setPresetLabel] = useState<string>(initialPreset.label);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -258,11 +258,11 @@ function SimpleSubmitForm({
           <div className="mt-1 grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3">
             {POINT_PRESETS.model.map((opt) => (
               <button
-                key={opt.value}
+                key={opt.label}
                 type="button"
-                onClick={() => setPoints(opt.value)}
+                onClick={() => { setPoints(opt.value); setPresetLabel(opt.label); }}
                 className={`flex flex-col items-center rounded border px-3 py-2 text-center text-sm transition-colors hover:border-brass/50 ${
-                  points === opt.value
+                  presetLabel === opt.label
                     ? 'border-brass bg-brass/10 text-parchment'
                     : 'border-brass/20 text-parchment-dim'
                 }`}
@@ -282,11 +282,11 @@ function SimpleSubmitForm({
           <div className="mt-1 grid grid-cols-1 gap-2 sm:grid-cols-3">
             {POINT_PRESETS.scribe.map((opt) => (
               <button
-                key={opt.value}
+                key={opt.label}
                 type="button"
-                onClick={() => setPoints(opt.value)}
+                onClick={() => { setPoints(opt.value); setPresetLabel(opt.label); }}
                 className={`flex flex-col items-center rounded border px-3 py-2 text-center text-sm transition-colors hover:border-brass/50 ${
-                  points === opt.value
+                  presetLabel === opt.label
                     ? 'border-brass bg-brass/10 text-parchment'
                     : 'border-brass/20 text-parchment-dim'
                 }`}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -94,12 +94,13 @@ export const POINT_PRESETS: Record<SubmissionType, { label: string; value: numbe
     { label: "Victory (grand, 2000pts+)", value: 15 },
   ],
   model: [
-    { label: "Character / Single Infantry Model", value: 2 },
+    { label: "Character / Single Infantry Model", value: 4 },
     { label: "Fireteam (3-5 models)", value: 5 },
     { label: "Squad (6-10 models)", value: 10 },
     { label: "Horde (11+ models)", value: 20 },
     { label: "Vehicle / monster", value: 8 },
     { label: "Titanic", value: 25 },
+    { label: "Painted Terrain", value: 4 },
   ],
   scribe: [
     { label: "Short vignette (<500 words)", value: 3 },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -94,7 +94,7 @@ export const POINT_PRESETS: Record<SubmissionType, { label: string; value: numbe
     { label: "Victory (grand, 2000pts+)", value: 15 },
   ],
   model: [
-    { label: "Character / Single Infantry Model", value: 4 },
+    { label: "Character", value: 4 },
     { label: "Fireteam (3-5 models)", value: 5 },
     { label: "Squad (6-10 models)", value: 10 },
     { label: "Horde (11+ models)", value: 20 },

--- a/supabase/migrations/0004_vlw_on_profile_insert.sql
+++ b/supabase/migrations/0004_vlw_on_profile_insert.sql
@@ -1,0 +1,55 @@
+-- ============================================================================
+-- 0004_vlw_on_profile_insert.sql
+--
+-- Fixes #41: Veteran of the Long War (one of the first ten accounts) did not
+-- fire for a new user who registered as the 8th account.
+--
+-- Root cause
+-- ----------
+-- VLW was only evaluated inside `evaluate_player_awards`, which runs on
+-- submission approval. A user who registers in the first 10 but has not yet
+-- had a submission approved never gets the badge. Even after the AFTER UPDATE
+-- evaluator pass from 0003, the badge is gated on the timing of an admin
+-- approval rather than on the event the badge actually rewards (account
+-- creation order).
+--
+-- Fix
+-- ---
+-- Grant VLW directly when the profile row is inserted, if total profile count
+-- is still <= 10. `_grant_award` is idempotent. A backfill at the end grants
+-- VLW to any of the current first-10 profiles (by created_at) that don't yet
+-- have it, covering users affected by the old behaviour.
+-- ============================================================================
+
+create or replace function public.grant_vlw_on_profile_insert()
+returns trigger
+language plpgsql
+security definer
+as $$
+begin
+  if (select count(*) from public.profiles) <= 10 then
+    perform public._grant_award(new.id, 'veteran_of_the_long_war');
+  end if;
+  return null;
+end $$;
+
+drop trigger if exists trg_grant_vlw_on_profile on public.profiles;
+create trigger trg_grant_vlw_on_profile
+after insert on public.profiles
+for each row execute function public.grant_vlw_on_profile_insert();
+
+-- Backfill: grant VLW to the first 10 profiles by created_at that don't have
+-- it yet.
+do $$
+declare
+  r record;
+begin
+  for r in
+    select id
+    from public.profiles
+    order by created_at
+    limit 10
+  loop
+    perform public._grant_award(r.id, 'veteran_of_the_long_war');
+  end loop;
+end $$;


### PR DESCRIPTION
## Summary

- **Closes #41**: Veteran of the Long War now grants immediately when a profile is created in the first 10 accounts. Previously the badge only ran inside `evaluate_player_awards`, which fires on submission approval — so a user in the first 10 who hadn't yet had a submission approved would never get it. New `AFTER INSERT` trigger on `public.profiles` grants VLW when the new row brings the total profile count to ≤ 10. A one-shot backfill grants it to any of the current first-10 profiles that are missing it.
- **Closes #40**: Adds a **Painted Terrain** preset (+4 glory) to the painted submission form, and raises **Character / Single Infantry Model** from +2 to +4.

## Files changed

- `supabase/migrations/0004_vlw_on_profile_insert.sql` (new): trigger + backfill
- `lib/types.ts`: `POINT_PRESETS.model` updates
- `README.md`: setup-step note for the new migration

## Test plan

- [x] Apply `0004_vlw_on_profile_insert.sql` to a dev Supabase project; confirm any of the first 10 profiles missing VLW now have it (`select count(*) from player_awards where award_id = (select id from awards where key = 'veteran_of_the_long_war')`).
- [x] Sign up an 11th test user in dev; confirm they do **not** receive VLW.
- [x] Sign up users when total profile count is < 10; confirm they do receive VLW at registration without needing a submission.
- [x] On the submit page, pick the painted kind and verify the Character preset shows **4 pts** and a new **Painted Terrain** option appears at **4 pts**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)