### PR TITLE
Ignore supabase/.temp local CLI state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ package-lock.json
 # Local working notes / scratch
 recap.md
 supabase/tmp_schema_dump_*.csv
+supabase/.temp/


### PR DESCRIPTION
## Summary
- Adds `supabase/.temp/` to `.gitignore`. That directory holds per-machine Supabase CLI state (linked project ref, auth tokens, postgres-version, etc.) and shouldn't be versioned.

## Test plan
- [ ] `git status` on a freshly-linked checkout no longer lists `supabase/.temp/`
- [ ] `gh pr create` no longer warns "1 uncommitted change"

🤖 Generated with [Claude Code](https://claude.com/claude-code)