### PR TITLE
Admin can change submission faction & type; scribe size auto-from-word-count (#46)

### DIFF
--- a/app/admin/AdminQueue.tsx
+++ b/app/admin/AdminQueue.tsx
@@ -4,9 +4,17 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import FactionEmblem from "@/components/FactionEmblem";
-import type { Submission, Planet, Faction } from "@/lib/types";
+import type { Submission, SubmissionType, Planet, Faction } from "@/lib/types";
 
 type Row = Submission & { profiles: { display_name: string } | null };
+
+const SUBMISSION_TYPE_OPTIONS: { value: SubmissionType; label: string }[] = [
+  { value: "game", label: "Battle Report" },
+  { value: "model", label: "Painted Unit" },
+  { value: "scribe", label: "Scribe" },
+  { value: "loremaster", label: "Loremaster" },
+  { value: "bonus", label: "Bonus" },
+];
 
 export function AdminQueue({
   submissions,
@@ -22,6 +30,7 @@ export function AdminQueue({
   const [adjustments, setAdjustments] = useState<Record<string, number>>({});
   const [notes, setNotes] = useState<Record<string, string>>({});
   const [factionOverrides, setFactionOverrides] = useState<Record<string, string | null>>({});
+  const [typeOverrides, setTypeOverrides] = useState<Record<string, SubmissionType>>({});
 
   const planetById = new Map(planets.map((p) => [p.id, p]));
   const factionById = new Map(factions.map((f) => [f.id, f]));
@@ -37,6 +46,9 @@ export function AdminQueue({
     const submission = submissions.find((s) => s.id === id);
     const hasFactionOverride = Object.prototype.hasOwnProperty.call(factionOverrides, id);
     const overrideFaction = hasFactionOverride ? factionOverrides[id] : undefined;
+    const hasTypeOverride = Object.prototype.hasOwnProperty.call(typeOverrides, id);
+    const overrideType = hasTypeOverride ? typeOverrides[id] : undefined;
+    const typeChanged = hasTypeOverride && overrideType !== submission?.type;
 
     const update: Record<string, unknown> = {
       status,
@@ -49,6 +61,24 @@ export function AdminQueue({
     }
     if (hasFactionOverride && overrideFaction !== (submission?.faction_id ?? null)) {
       update.faction_id = overrideFaction;
+    }
+    if (typeChanged && overrideType) {
+      update.type = overrideType;
+      if (overrideType !== "game") {
+        update.result = null;
+        update.opponent_name = null;
+        update.adversary_user_id = null;
+        update.adversary_faction_id = null;
+        update.game_system_id = null;
+        update.game_size = null;
+        update.video_game_title_id = null;
+      }
+      if (overrideType !== "loremaster") {
+        update.lore_title = null;
+        update.lore_format = null;
+        update.lore_rating = null;
+        update.lore_reflection = null;
+      }
     }
 
     const { error } = await supabase
@@ -80,6 +110,9 @@ export function AdminQueue({
         const selectedFactionId = hasFactionOverride ? factionOverrides[s.id] : s.faction_id;
         const faction = selectedFactionId ? factionById.get(selectedFactionId) : null;
         const factionChanged = hasFactionOverride && selectedFactionId !== s.faction_id;
+        const hasTypeOverride = Object.prototype.hasOwnProperty.call(typeOverrides, s.id);
+        const selectedType = hasTypeOverride ? typeOverrides[s.id] : s.type;
+        const typeChanged = hasTypeOverride && selectedType !== s.type;
         const adjusted = adjustments[s.id] ?? s.points;
 
         return (
@@ -88,7 +121,7 @@ export function AdminQueue({
               <div>
                 <div className="flex items-center gap-3 mb-1 flex-wrap">
                   <span className="font-display text-xs uppercase tracking-widest text-brass px-2 py-0.5 border border-brass/40">
-                    {s.type}
+                    {selectedType}
                   </span>
                   {s.type === "game" && s.result && (
                     <span
@@ -154,51 +187,84 @@ export function AdminQueue({
               />
             )}
 
-            <div className="grid md:grid-cols-3 gap-4 pt-4 border-t border-brass/10">
-              <div>
-                <label className="label">Adjust Points</label>
-                <input
-                  type="number"
-                  min={0}
-                  value={adjusted}
-                  onChange={(e) =>
-                    setAdjustments((a) => ({
-                      ...a,
-                      [s.id]: Number(e.target.value),
-                    }))
-                  }
-                  className="input w-full"
-                />
-              </div>
-              <div>
-                <label className="label">
-                  Faction
-                  {factionChanged && (
-                    <span className="ml-2 text-xs text-crusade normal-case tracking-normal">
-                      changed
-                    </span>
-                  )}
-                </label>
-                <select
-                  value={selectedFactionId ?? ""}
-                  onChange={(e) =>
-                    setFactionOverrides((f) => ({
-                      ...f,
-                      [s.id]: e.target.value === "" ? null : e.target.value,
-                    }))
-                  }
-                  className="input w-full"
-                >
-                  <option value="" className="bg-ink text-parchment">
-                    (no faction)
-                  </option>
-                  {sortedFactions.map((f) => (
-                    <option key={f.id} value={f.id} className="bg-ink text-parchment">
-                      {f.name}
+            <div className="pt-4 border-t border-brass/10 space-y-4">
+              <div className="grid md:grid-cols-3 gap-4">
+                <div>
+                  <label className="label">Adjust Points</label>
+                  <input
+                    type="number"
+                    min={0}
+                    value={adjusted}
+                    onChange={(e) =>
+                      setAdjustments((a) => ({
+                        ...a,
+                        [s.id]: Number(e.target.value),
+                      }))
+                    }
+                    className="input w-full"
+                  />
+                </div>
+                <div>
+                  <label className="label">
+                    Type
+                    {typeChanged && (
+                      <span className="ml-2 text-xs text-crusade normal-case tracking-normal">
+                        changed
+                      </span>
+                    )}
+                  </label>
+                  <select
+                    value={selectedType}
+                    onChange={(e) =>
+                      setTypeOverrides((t) => ({
+                        ...t,
+                        [s.id]: e.target.value as SubmissionType,
+                      }))
+                    }
+                    className="input w-full"
+                  >
+                    {SUBMISSION_TYPE_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value} className="bg-ink text-parchment">
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="label">
+                    Faction
+                    {factionChanged && (
+                      <span className="ml-2 text-xs text-crusade normal-case tracking-normal">
+                        changed
+                      </span>
+                    )}
+                  </label>
+                  <select
+                    value={selectedFactionId ?? ""}
+                    onChange={(e) =>
+                      setFactionOverrides((f) => ({
+                        ...f,
+                        [s.id]: e.target.value === "" ? null : e.target.value,
+                      }))
+                    }
+                    className="input w-full"
+                  >
+                    <option value="" className="bg-ink text-parchment">
+                      (no faction)
                     </option>
-                  ))}
-                </select>
+                    {sortedFactions.map((f) => (
+                      <option key={f.id} value={f.id} className="bg-ink text-parchment">
+                        {f.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
               </div>
+              {typeChanged && (
+                <p className="text-xs italic text-parchment-dark">
+                  Type changed from <span className="text-parchment">{s.type}</span> to <span className="text-parchment">{selectedType}</span>. Any type-specific fields (battle result, lore rating, etc.) will be cleared on save.
+                </p>
+              )}
               <div>
                 <label className="label">Review Notes (optional)</label>
                 <input

--- a/app/admin/AdminQueue.tsx
+++ b/app/admin/AdminQueue.tsx
@@ -21,9 +21,11 @@ export function AdminQueue({
   const [workingId, setWorkingId] = useState<string | null>(null);
   const [adjustments, setAdjustments] = useState<Record<string, number>>({});
   const [notes, setNotes] = useState<Record<string, string>>({});
+  const [factionOverrides, setFactionOverrides] = useState<Record<string, string | null>>({});
 
   const planetById = new Map(planets.map((p) => [p.id, p]));
   const factionById = new Map(factions.map((f) => [f.id, f]));
+  const sortedFactions = [...factions].sort((a, b) => a.name.localeCompare(b.name));
 
   async function review(id: string, status: "approved" | "rejected") {
     setWorkingId(id);
@@ -32,6 +34,9 @@ export function AdminQueue({
     const { data: { user } } = await supabase.auth.getUser();
     const finalPoints = adjustments[id];
     const reviewNote = notes[id] || null;
+    const submission = submissions.find((s) => s.id === id);
+    const hasFactionOverride = Object.prototype.hasOwnProperty.call(factionOverrides, id);
+    const overrideFaction = hasFactionOverride ? factionOverrides[id] : undefined;
 
     const update: Record<string, unknown> = {
       status,
@@ -41,6 +46,9 @@ export function AdminQueue({
     };
     if (status === "approved" && typeof finalPoints === "number") {
       update.points = finalPoints;
+    }
+    if (hasFactionOverride && overrideFaction !== (submission?.faction_id ?? null)) {
+      update.faction_id = overrideFaction;
     }
 
     const { error } = await supabase
@@ -68,7 +76,10 @@ export function AdminQueue({
     <div className="space-y-4">
       {submissions.map((s) => {
         const planet = s.target_planet_id ? planetById.get(s.target_planet_id) : null;
-        const faction = s.faction_id ? factionById.get(s.faction_id) : null;
+        const hasFactionOverride = Object.prototype.hasOwnProperty.call(factionOverrides, s.id);
+        const selectedFactionId = hasFactionOverride ? factionOverrides[s.id] : s.faction_id;
+        const faction = selectedFactionId ? factionById.get(selectedFactionId) : null;
+        const factionChanged = hasFactionOverride && selectedFactionId !== s.faction_id;
         const adjusted = adjustments[s.id] ?? s.points;
 
         return (
@@ -143,7 +154,7 @@ export function AdminQueue({
               />
             )}
 
-            <div className="grid md:grid-cols-2 gap-4 pt-4 border-t border-brass/10">
+            <div className="grid md:grid-cols-3 gap-4 pt-4 border-t border-brass/10">
               <div>
                 <label className="label">Adjust Points</label>
                 <input
@@ -158,6 +169,35 @@ export function AdminQueue({
                   }
                   className="input w-full"
                 />
+              </div>
+              <div>
+                <label className="label">
+                  Faction
+                  {factionChanged && (
+                    <span className="ml-2 text-xs text-crusade normal-case tracking-normal">
+                      changed
+                    </span>
+                  )}
+                </label>
+                <select
+                  value={selectedFactionId ?? ""}
+                  onChange={(e) =>
+                    setFactionOverrides((f) => ({
+                      ...f,
+                      [s.id]: e.target.value === "" ? null : e.target.value,
+                    }))
+                  }
+                  className="input w-full"
+                >
+                  <option value="" className="bg-ink text-parchment">
+                    (no faction)
+                  </option>
+                  {sortedFactions.map((f) => (
+                    <option key={f.id} value={f.id} className="bg-ink text-parchment">
+                      {f.name}
+                    </option>
+                  ))}
+                </select>
               </div>
               <div>
                 <label className="label">Review Notes (optional)</label>

--- a/app/submit/SubmitPageClient.tsx
+++ b/app/submit/SubmitPageClient.tsx
@@ -8,13 +8,24 @@
 // and Scribe (writing) share the simple form.
 // =====================================================================
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { uploadImage } from '@/lib/upload-image';
 import BattleSubmitForm from '@/components/BattleSubmitForm';
 import { POINT_PRESETS } from '@/lib/types';
 import type { GameSystemId, LoreFormat } from '@/lib/types';
+
+function countWords(s: string): number {
+  const trimmed = s.trim();
+  return trimmed ? trimmed.split(/\s+/).length : 0;
+}
+
+function scribeBracketFor(words: number) {
+  if (words >= 1500) return POINT_PRESETS.scribe[2];
+  if (words >= 500)  return POINT_PRESETS.scribe[1];
+  return POINT_PRESETS.scribe[0];
+}
 
 interface Planet  { id: string; name: string; }
 interface Faction { id: string; name: string; }
@@ -117,6 +128,15 @@ function SimpleSubmitForm({
   const [presetLabel, setPresetLabel] = useState<string>(initialPreset.label);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const scribeWordCount = kind === 'scribe' ? countWords(description) : 0;
+  const scribeBracket   = kind === 'scribe' ? scribeBracketFor(scribeWordCount) : null;
+
+  useEffect(() => {
+    if (kind !== 'scribe' || !scribeBracket) return;
+    setPoints(scribeBracket.value);
+    setPresetLabel(scribeBracket.label);
+  }, [kind, scribeBracket?.value, scribeBracket?.label]);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -280,24 +300,25 @@ function SimpleSubmitForm({
         <div>
           <span className="label">Claimed points</span>
           <div className="mt-1 grid grid-cols-1 gap-2 sm:grid-cols-3">
-            {POINT_PRESETS.scribe.map((opt) => (
-              <button
-                key={opt.label}
-                type="button"
-                onClick={() => { setPoints(opt.value); setPresetLabel(opt.label); }}
-                className={`flex flex-col items-center rounded border px-3 py-2 text-center text-sm transition-colors hover:border-brass/50 ${
-                  presetLabel === opt.label
-                    ? 'border-brass bg-brass/10 text-parchment'
-                    : 'border-brass/20 text-parchment-dim'
-                }`}
-              >
-                <span>{opt.label}</span>
-                <span className="text-xs opacity-80">{opt.value} pts</span>
-              </button>
-            ))}
+            {POINT_PRESETS.scribe.map((opt) => {
+              const active = scribeBracket?.label === opt.label;
+              return (
+                <div
+                  key={opt.label}
+                  className={`flex flex-col items-center rounded border px-3 py-2 text-center text-sm ${
+                    active
+                      ? 'border-brass bg-brass/10 text-parchment'
+                      : 'border-brass/20 text-parchment-dim'
+                  }`}
+                >
+                  <span>{opt.label}</span>
+                  <span className="text-xs opacity-80">{opt.value} pts</span>
+                </div>
+              );
+            })}
           </div>
           <p className="mt-1 text-xs italic text-parchment-dark">
-            The Inquisition may adjust this value upon review.
+            Auto-selected from your word count ({scribeWordCount.toLocaleString()} {scribeWordCount === 1 ? 'word' : 'words'}). The Inquisition may adjust upon review.
           </p>
         </div>
       )}


### PR DESCRIPTION
## Summary

**Admin approval queue** (`app/admin/AdminQueue.tsx`)
- Adds a **Faction** dropdown so admins can correct a player's faction before approving — addresses #46.
- Adds a **Type** dropdown so admins can re-classify a submission (e.g. scribe → model when a player files painted models under the wrong type). When the type changes, type-specific columns are cleared so they don't bleed into the new type:
  - Away from `game` → nulls `result`, `opponent_name`, `adversary_user_id`, `adversary_faction_id`, `game_system_id`, `game_size`, `video_game_title_id`.
  - Away from `loremaster` → nulls `lore_title`, `lore_format`, `lore_rating`, `lore_reflection`.
- The header chip and faction emblem live-update to reflect overrides; a "changed" tag appears next to the affected label.
- The existing `award_points_on_approval` trigger uses `new.faction_id` and `new.type`, so planet points, faction totals, mirror submissions, and ELO are credited to the corrected values on approval.

**Scribe submission** (`app/submit/SubmitPageClient.tsx`)
- The scribe bracket (<500w vignette / 500-1499w short story / 1500+w long-form) is now auto-derived from the body's word count instead of selected manually.
- Buttons become read-only indicators; a live word count appears below.
- Removes the temptation to over-claim and the friction of picking a bracket.

Closes #46.

## Test plan
- [x] Admin queue: change a pending submission's faction, approve, and confirm the corrected faction is credited on `/leaderboard`, `/map`, and the submitter's profile.
- [x] Admin queue: change a pending `scribe` to `model`, approve, and confirm it shows up as a painted model on the profile/feed with no stale lore fields.
- [x] Admin queue: change a pending `game` to `bonus`, approve, and confirm no ELO/mirror is generated and `result`/`adversary_*` are nulled.
- [x] Admin queue: change type then click Reject — submission is rejected and the corrected type/cleared fields persist.
- [x] Submit a scribe deed with various body lengths and watch the bracket auto-update (<500, 500-1499, 1500+); confirm the persisted `points` matches the bracket.
- [x] Submit a scribe deed with an empty body — bracket defaults to vignette (3 pts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)