### PR TITLE
Per-video-game ELO and admin editing of more submission fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The schema is split into SQL files because PostgreSQL forbids referencing a newl
 3. Open a fresh **New query**, paste the contents of `supabase/migrations/0002_features.sql`, and **Run**. This adds the loremaster reading-track features and Season Administration RPC.
 4. Open a fresh **New query**, paste the contents of `supabase/migrations/0003_fix_award_evaluation_timing.sql`, and **Run**. This fixes an off-by-one in award evaluation so threshold-based badges (First Blood, Brush Initiate, etc.) fire on the first qualifying approval rather than the second.
 5. Open a fresh **New query**, paste the contents of `supabase/migrations/0004_vlw_on_profile_insert.sql`, and **Run**. This grants Veteran of the Long War at account-creation time (instead of waiting for a first approval) and backfills the badge for the first 10 existing profiles.
+6. Open a fresh **New query**, paste the contents of `supabase/migrations/0015_video_game_per_title_elo.sql`, and **Run**. This splits video-game ELO ratings out by individual title (Dawn of War, Battlesector, etc.) instead of pooling every video game into one rating; the migration wipes existing `video` ELO rows and replays approved video matches in time order to rebuild per-title ratings.
 
 All files are idempotent (they use `if not exists` / `on conflict do update` / `create or replace`), so you can safely re-run them.
 

--- a/app/admin/AdminQueue.tsx
+++ b/app/admin/AdminQueue.tsx
@@ -1,10 +1,22 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import FactionEmblem from "@/components/FactionEmblem";
-import type { Submission, SubmissionType, Planet, Faction } from "@/lib/types";
+import AdversaryPicker, { type AdversaryValue } from "@/components/AdversaryPicker";
+import type {
+  Submission,
+  SubmissionType,
+  Planet,
+  Faction,
+  GameSystem,
+  GameSystemId,
+  GameSize,
+  PointScheme,
+  VideoGameTitle,
+  PlanetGameSystem,
+} from "@/lib/types";
 
 type Row = Submission & { profiles: { display_name: string } | null };
 
@@ -16,14 +28,56 @@ const SUBMISSION_TYPE_OPTIONS: { value: SubmissionType; label: string }[] = [
   { value: "bonus", label: "Bonus" },
 ];
 
+const SIZE_LABEL: Record<GameSize, string> = {
+  small: "Small",
+  standard: "Standard",
+  large: "Large",
+  "n/a": "N/A",
+};
+
+interface GameOverride {
+  target_planet_id: string | null;
+  game_system_id: GameSystemId | null;
+  game_size: GameSize | null;
+  video_game_title_id: number | null;
+  adversary: AdversaryValue;
+}
+
+function initialAdversary(s: Row, factionById: Map<string, Faction>): AdversaryValue {
+  return {
+    name: s.opponent_name ?? "",
+    userId: s.adversary_user_id,
+    factionId: s.adversary_faction_id,
+    factionName: s.adversary_faction_id ? factionById.get(s.adversary_faction_id)?.name ?? null : null,
+  };
+}
+
+function initialGame(s: Row, factionById: Map<string, Faction>): GameOverride {
+  return {
+    target_planet_id: s.target_planet_id,
+    game_system_id: (s.game_system_id as GameSystemId | null) ?? null,
+    game_size: s.game_size,
+    video_game_title_id: s.video_game_title_id,
+    adversary: initialAdversary(s, factionById),
+  };
+}
+
 export function AdminQueue({
   submissions,
   planets,
   factions,
+  gameSystems,
+  pointSchemes,
+  videoGameTitles,
+  planetSystems,
 }: {
   submissions: Row[];
   planets: Planet[];
   factions: Faction[];
+  gameSystems: GameSystem[];
+  pointSchemes: PointScheme[];
+  videoGameTitles: VideoGameTitle[];
+  planetSystems: PlanetGameSystem[];
 }) {
   const router = useRouter();
   const [workingId, setWorkingId] = useState<string | null>(null);
@@ -31,24 +85,73 @@ export function AdminQueue({
   const [notes, setNotes] = useState<Record<string, string>>({});
   const [factionOverrides, setFactionOverrides] = useState<Record<string, string | null>>({});
   const [typeOverrides, setTypeOverrides] = useState<Record<string, SubmissionType>>({});
+  const [gameOverrides, setGameOverrides] = useState<Record<string, GameOverride>>({});
 
   const planetById = new Map(planets.map((p) => [p.id, p]));
   const factionById = new Map(factions.map((f) => [f.id, f]));
+  const systemById = new Map(gameSystems.map((g) => [g.id, g]));
+  const videoGameById = new Map(videoGameTitles.map((v) => [v.id, v]));
   const sortedFactions = [...factions].sort((a, b) => a.name.localeCompare(b.name));
+  const sortedPlanets = [...planets].sort((a, b) => a.name.localeCompare(b.name));
+
+  const allowedSystemsByPlanet = useMemo(() => {
+    const map = new Map<string, Set<GameSystemId>>();
+    for (const row of planetSystems) {
+      const set = map.get(row.planet_id) ?? new Set<GameSystemId>();
+      set.add(row.game_system_id);
+      map.set(row.planet_id, set);
+    }
+    return map;
+  }, [planetSystems]);
+
+  function allowedSystemsFor(planetId: string | null): GameSystem[] {
+    if (!planetId) return gameSystems;
+    const set = allowedSystemsByPlanet.get(planetId);
+    if (!set || set.size === 0) return gameSystems;
+    return gameSystems.filter((s) => set.has(s.id));
+  }
+
+  function pointsFor(systemId: GameSystemId | null, size: GameSize | null, result: string | null): number | null {
+    if (!systemId || !result) return null;
+    const sz = size ?? "n/a";
+    const match = pointSchemes.find(
+      (ps) => ps.game_system_id === systemId && ps.game_size === sz && ps.result === result,
+    );
+    return match?.points ?? null;
+  }
+
+  function getGameState(s: Row): GameOverride {
+    return gameOverrides[s.id] ?? initialGame(s, factionById);
+  }
+
+  function setGameState(id: string, patch: Partial<GameOverride>, baseRow: Row) {
+    setGameOverrides((prev) => {
+      const current = prev[id] ?? initialGame(baseRow, factionById);
+      return { ...prev, [id]: { ...current, ...patch } };
+    });
+  }
 
   async function review(id: string, status: "approved" | "rejected") {
     setWorkingId(id);
     const supabase = createClient();
 
     const { data: { user } } = await supabase.auth.getUser();
+    const submission = submissions.find((s) => s.id === id);
+    if (!submission) {
+      setWorkingId(null);
+      return;
+    }
+
     const finalPoints = adjustments[id];
     const reviewNote = notes[id] || null;
-    const submission = submissions.find((s) => s.id === id);
     const hasFactionOverride = Object.prototype.hasOwnProperty.call(factionOverrides, id);
     const overrideFaction = hasFactionOverride ? factionOverrides[id] : undefined;
     const hasTypeOverride = Object.prototype.hasOwnProperty.call(typeOverrides, id);
     const overrideType = hasTypeOverride ? typeOverrides[id] : undefined;
-    const typeChanged = hasTypeOverride && overrideType !== submission?.type;
+    const effectiveType = overrideType ?? submission.type;
+    const typeChanged = hasTypeOverride && overrideType !== submission.type;
+    const hasGameOverride = Object.prototype.hasOwnProperty.call(gameOverrides, id);
+    const game = hasGameOverride ? gameOverrides[id] : null;
 
     const update: Record<string, unknown> = {
       status,
@@ -59,7 +162,7 @@ export function AdminQueue({
     if (status === "approved" && typeof finalPoints === "number") {
       update.points = finalPoints;
     }
-    if (hasFactionOverride && overrideFaction !== (submission?.faction_id ?? null)) {
+    if (hasFactionOverride && overrideFaction !== (submission.faction_id ?? null)) {
       update.faction_id = overrideFaction;
     }
     if (typeChanged && overrideType) {
@@ -78,6 +181,37 @@ export function AdminQueue({
         update.lore_format = null;
         update.lore_rating = null;
         update.lore_reflection = null;
+      }
+    }
+
+    if (effectiveType === "game" && game) {
+      if (game.target_planet_id !== submission.target_planet_id) {
+        update.target_planet_id = game.target_planet_id;
+      }
+      if (game.game_system_id !== (submission.game_system_id ?? null)) {
+        update.game_system_id = game.game_system_id;
+      }
+      if (game.game_size !== submission.game_size) {
+        update.game_size = game.game_size;
+      }
+      if (game.video_game_title_id !== submission.video_game_title_id) {
+        update.video_game_title_id = game.video_game_title_id;
+      }
+      const newName = game.adversary.name.trim() || null;
+      if (newName !== submission.opponent_name) update.opponent_name = newName;
+      if (game.adversary.userId !== submission.adversary_user_id) {
+        update.adversary_user_id = game.adversary.userId;
+      }
+      if (game.adversary.factionId !== submission.adversary_faction_id) {
+        update.adversary_faction_id = game.adversary.factionId;
+      }
+    }
+
+    if (status === "approved" && effectiveType === "game") {
+      if (game?.adversary.userId && !game.adversary.factionId) {
+        setWorkingId(null);
+        alert("Pick which faction the linked opponent fielded before approving.");
+        return;
       }
     }
 
@@ -114,6 +248,11 @@ export function AdminQueue({
         const selectedType = hasTypeOverride ? typeOverrides[s.id] : s.type;
         const typeChanged = hasTypeOverride && selectedType !== s.type;
         const adjusted = adjustments[s.id] ?? s.points;
+        const game = getGameState(s);
+        const currentSystem = game.game_system_id ? systemById.get(game.game_system_id) ?? null : null;
+        const allowedSystems = allowedSystemsFor(game.target_planet_id);
+        const suggestedPoints = pointsFor(game.game_system_id, game.game_size, s.result);
+        const battleEditable = selectedType === "game";
 
         return (
           <div key={s.id} className="card p-6">
@@ -203,6 +342,15 @@ export function AdminQueue({
                     }
                     className="input w-full"
                   />
+                  {battleEditable && suggestedPoints !== null && suggestedPoints !== adjusted && (
+                    <button
+                      type="button"
+                      onClick={() => setAdjustments((a) => ({ ...a, [s.id]: suggestedPoints }))}
+                      className="mt-1 text-xs text-brass hover:text-brass-bright underline"
+                    >
+                      Use scheme suggestion: {suggestedPoints}
+                    </button>
+                  )}
                 </div>
                 <div>
                   <label className="label">
@@ -260,11 +408,165 @@ export function AdminQueue({
                   </select>
                 </div>
               </div>
-              {typeChanged && (
-                <p className="text-xs italic text-parchment-dark">
-                  Type changed from <span className="text-parchment">{s.type}</span> to <span className="text-parchment">{selectedType}</span>. Any type-specific fields (battle result, lore rating, etc.) will be cleared on save.
-                </p>
+
+              {battleEditable && (
+                <div className="rounded border border-brass/20 bg-ink/40 p-4 space-y-4">
+                  <div className="font-display uppercase tracking-widest text-xs text-brass-bright">
+                    Battle Details
+                  </div>
+
+                  <div className="grid md:grid-cols-3 gap-4">
+                    <div>
+                      <label className="label">Planet</label>
+                      <select
+                        value={game.target_planet_id ?? ""}
+                        onChange={(e) => {
+                          const newPlanetId = e.target.value === "" ? null : e.target.value;
+                          const newAllowed = allowedSystemsFor(newPlanetId);
+                          const stillAllowed =
+                            game.game_system_id && newAllowed.some((sys) => sys.id === game.game_system_id);
+                          const snappedSystem: GameSystemId | null = stillAllowed
+                            ? game.game_system_id
+                            : newAllowed[0]?.id ?? null;
+                          const snappedSystemDef = snappedSystem ? systemById.get(snappedSystem) : null;
+                          const snappedSize: GameSize | null = snappedSystemDef
+                            ? snappedSystemDef.supports_size
+                              ? game.game_size && game.game_size !== "n/a"
+                                ? game.game_size
+                                : "standard"
+                              : "n/a"
+                            : game.game_size;
+                          const snappedVg: number | null = snappedSystemDef?.supports_video_game
+                            ? game.video_game_title_id
+                            : null;
+                          setGameState(
+                            s.id,
+                            {
+                              target_planet_id: newPlanetId,
+                              game_system_id: snappedSystem,
+                              game_size: snappedSize,
+                              video_game_title_id: snappedVg,
+                            },
+                            s,
+                          );
+                        }}
+                        className="input w-full"
+                      >
+                        <option value="" className="bg-ink text-parchment">
+                          (no planet)
+                        </option>
+                        {sortedPlanets.map((p) => (
+                          <option key={p.id} value={p.id} className="bg-ink text-parchment">
+                            {p.name}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div>
+                      <label className="label">Game System</label>
+                      <select
+                        value={game.game_system_id ?? ""}
+                        onChange={(e) => {
+                          const newId = (e.target.value || null) as GameSystemId | null;
+                          const def = newId ? systemById.get(newId) : null;
+                          const newSize: GameSize | null = def
+                            ? def.supports_size
+                              ? game.game_size && game.game_size !== "n/a"
+                                ? game.game_size
+                                : "standard"
+                              : "n/a"
+                            : null;
+                          const newVg: number | null = def?.supports_video_game
+                            ? game.video_game_title_id
+                            : null;
+                          setGameState(
+                            s.id,
+                            { game_system_id: newId, game_size: newSize, video_game_title_id: newVg },
+                            s,
+                          );
+                        }}
+                        className="input w-full"
+                      >
+                        <option value="" className="bg-ink text-parchment">
+                          — select —
+                        </option>
+                        {allowedSystems.map((sys) => (
+                          <option key={sys.id} value={sys.id} className="bg-ink text-parchment">
+                            {sys.name}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div>
+                      <label className="label">Battle Size</label>
+                      <select
+                        value={game.game_size ?? ""}
+                        disabled={!currentSystem || !currentSystem.supports_size}
+                        onChange={(e) =>
+                          setGameState(
+                            s.id,
+                            { game_size: (e.target.value || null) as GameSize | null },
+                            s,
+                          )
+                        }
+                        className="input w-full disabled:opacity-60"
+                      >
+                        {currentSystem?.supports_size ? (
+                          (["small", "standard", "large"] as GameSize[]).map((sz) => (
+                            <option key={sz} value={sz} className="bg-ink text-parchment">
+                              {SIZE_LABEL[sz]}
+                            </option>
+                          ))
+                        ) : (
+                          <option value={game.game_size ?? "n/a"} className="bg-ink text-parchment">
+                            {SIZE_LABEL[game.game_size ?? "n/a"]}
+                          </option>
+                        )}
+                      </select>
+                    </div>
+                  </div>
+
+                  {currentSystem?.supports_video_game && (
+                    <div>
+                      <label className="label">Video Game</label>
+                      <select
+                        value={game.video_game_title_id ?? ""}
+                        onChange={(e) =>
+                          setGameState(
+                            s.id,
+                            { video_game_title_id: e.target.value === "" ? null : Number(e.target.value) },
+                            s,
+                          )
+                        }
+                        className="input w-full"
+                      >
+                        <option value="" className="bg-ink text-parchment">
+                          — select a title —
+                        </option>
+                        {videoGameTitles.map((v) => (
+                          <option key={v.id} value={v.id} className="bg-ink text-parchment">
+                            {v.name}
+                          </option>
+                        ))}
+                      </select>
+                      {game.video_game_title_id && (
+                        <p className="mt-1 text-xs italic text-parchment-dark">
+                          Approving will rate ELO for {videoGameById.get(game.video_game_title_id)?.name ?? "this title"}.
+                        </p>
+                      )}
+                    </div>
+                  )}
+
+                  <AdversaryPicker
+                    value={game.adversary}
+                    onChange={(v) => setGameState(s.id, { adversary: v }, s)}
+                    currentUserId={s.player_id}
+                  />
+                </div>
               )}
+
               <div>
                 <label className="label">Review Notes (optional)</label>
                 <input
@@ -277,6 +579,11 @@ export function AdminQueue({
                   placeholder="Reason for rejection, or a commendation…"
                 />
               </div>
+              {typeChanged && (
+                <p className="text-xs italic text-parchment-dark">
+                  Type changed from <span className="text-parchment">{s.type}</span> to <span className="text-parchment">{selectedType}</span>. Any type-specific fields (battle result, lore rating, etc.) will be cleared on save.
+                </p>
+              )}
             </div>
 
             <div className="flex gap-3 justify-end mt-4">

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -11,6 +11,8 @@ import type {
   Profile,
   GameSystem,
   PlanetGameSystem,
+  PointScheme,
+  VideoGameTitle,
 } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
@@ -43,6 +45,8 @@ export default async function AdminPage() {
     { data: factions },
     { data: gameSystems },
     { data: planetSystems },
+    { data: pointSchemes },
+    { data: videoGames },
   ] = await Promise.all([
     supabase
       .from("submissions")
@@ -53,6 +57,8 @@ export default async function AdminPage() {
     supabase.from("factions").select("*").order("name"),
     supabase.from("game_systems").select("*").order("sort_order"),
     supabase.from("planet_game_systems").select("planet_id, game_system_id"),
+    supabase.from("point_schemes").select("*"),
+    supabase.from("video_game_titles").select("*").order("sort_order"),
   ]);
 
   return (
@@ -78,6 +84,10 @@ export default async function AdminPage() {
           submissions={(pending ?? []) as PendingSubmission[]}
           planets={(planets ?? []) as Planet[]}
           factions={(factions ?? []) as Faction[]}
+          gameSystems={(gameSystems ?? []) as GameSystem[]}
+          pointSchemes={(pointSchemes ?? []) as PointScheme[]}
+          videoGameTitles={(videoGames ?? []) as VideoGameTitle[]}
+          planetSystems={(planetSystems ?? []) as PlanetGameSystem[]}
         />
       </section>
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -27,6 +27,7 @@ export const dynamic = 'force-dynamic';
 interface EloRow {
   game_system_id: string;
   faction_id: string;
+  video_game_title_id: number | null;
   rating: number;
   games_played: number;
   wins: number;
@@ -34,6 +35,7 @@ interface EloRow {
   draws: number;
   factions: { name: string; color: string | null; emblem_url: string | null } | null;
   game_systems: { short_name: string; name: string } | null;
+  video_game_titles: { name: string } | null;
 }
 
 interface SubRow {
@@ -80,7 +82,7 @@ export default async function DashboardPage() {
       .maybeSingle(),
     supabase
       .from('elo_ratings')
-      .select('game_system_id, faction_id, rating, games_played, wins, losses, draws, factions(name, color, emblem_url), game_systems(short_name, name)')
+      .select('game_system_id, faction_id, video_game_title_id, rating, games_played, wins, losses, draws, factions(name, color, emblem_url), game_systems(short_name, name), video_game_titles(name)')
       .eq('user_id', user.id)
       .order('rating', { ascending: false }),
     supabase
@@ -220,8 +222,12 @@ export default async function DashboardPage() {
               </thead>
               <tbody>
                 {elo.map((r) => (
-                  <tr key={`${r.game_system_id}-${r.faction_id}`} className="border-b border-brass/5">
-                    <td className="p-2 text-parchment">{r.game_systems?.short_name ?? r.game_system_id}</td>
+                  <tr key={`${r.game_system_id}-${r.faction_id}-${r.video_game_title_id ?? 'na'}`} className="border-b border-brass/5">
+                    <td className="p-2 text-parchment">
+                      {r.video_game_titles?.name
+                        ?? r.game_systems?.short_name
+                        ?? r.game_system_id}
+                    </td>
                     <td className="p-2">
                       <span className="inline-flex items-center gap-2 text-parchment">
                         {r.factions?.emblem_url && r.factions.color ? (

--- a/app/player/[id]/page.tsx
+++ b/app/player/[id]/page.tsx
@@ -45,6 +45,7 @@ interface FactionMembership {
 interface EloRow {
   game_system_id: string;
   faction_id: string;
+  video_game_title_id: number | null;
   rating: number;
   games_played: number;
   wins: number;
@@ -52,6 +53,7 @@ interface EloRow {
   draws: number;
   factions: { name: string; color: string | null; emblem_url: string | null } | null;
   game_systems: { name: string; short_name: string } | null;
+  video_game_titles: { name: string } | null;
 }
 
 export default async function PlayerProfilePage({ params }: PageProps) {
@@ -74,7 +76,7 @@ export default async function PlayerProfilePage({ params }: PageProps) {
       .eq('user_id', id),
     supabase
       .from('elo_ratings')
-      .select('game_system_id, faction_id, rating, games_played, wins, losses, draws, factions(name, color, emblem_url), game_systems(name, short_name)')
+      .select('game_system_id, faction_id, video_game_title_id, rating, games_played, wins, losses, draws, factions(name, color, emblem_url), game_systems(name, short_name), video_game_titles(name)')
       .eq('user_id', id)
       .order('rating', { ascending: false }),
     supabase
@@ -252,8 +254,12 @@ export default async function PlayerProfilePage({ params }: PageProps) {
               </thead>
               <tbody className="divide-y divide-brass/20">
                 {eloRows.map((r) => (
-                  <tr key={`${r.game_system_id}-${r.faction_id}`} className="text-parchment">
-                    <td className="px-3 py-2">{r.game_systems?.short_name ?? r.game_system_id}</td>
+                  <tr key={`${r.game_system_id}-${r.faction_id}-${r.video_game_title_id ?? 'na'}`} className="text-parchment">
+                    <td className="px-3 py-2">
+                      {r.video_game_titles?.name
+                        ?? r.game_systems?.short_name
+                        ?? r.game_system_id}
+                    </td>
                     <td className="px-3 py-2">
                       <span className="inline-flex items-center gap-2">
                         {r.factions?.emblem_url && r.factions.color ? (

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -54,6 +54,11 @@ export type Submission = {
   lore_format: LoreFormat | null;
   lore_rating: number | null;
   lore_reflection: string | null;
+  game_system_id: string | null;
+  game_size: GameSize | null;
+  video_game_title_id: number | null;
+  adversary_user_id: string | null;
+  adversary_faction_id: string | null;
 };
 
 export type FactionTotal = {
@@ -189,6 +194,7 @@ export interface EloRating {
   user_id: string;
   game_system_id: GameSystemId;
   faction_id: string;
+  video_game_title_id: number | null;
   rating: number;
   games_played: number;
   wins: number;

--- a/supabase/migrations/0015_video_game_per_title_elo.sql
+++ b/supabase/migrations/0015_video_game_per_title_elo.sql
@@ -1,0 +1,487 @@
+-- ============================================================================
+-- 0015_video_game_per_title_elo.sql
+--
+-- Issue #49: ELO ratings for video games were lumped together under a single
+-- game_system_id = 'video' rating, regardless of which video game was played.
+-- That collapsed Dawn of War, Battlesector, Space Marine 2 etc. into one
+-- combined ladder. Tabletop systems remain one rating per (player, system,
+-- faction) — they are themselves distinct rule sets.
+--
+-- This migration:
+--   1. Adds `video_game_title_id` to elo_ratings (nullable; only set when the
+--      ELO row is for a video-game match).
+--   2. Replaces the primary key with a unique index using NULLS NOT DISTINCT
+--      (PG 15+) so the NULL on non-video rows is treated as a real value and
+--      collisions on (user, system, faction) are still prevented.
+--   3. Extends get_or_create_elo() with a video_game_title_id parameter.
+--   4. Replaces award_points_on_approval to pass video_game_title_id through
+--      to the ELO functions when game_system_id = 'video'.
+--   5. Backfills: deletes existing 'video' elo_ratings rows (they pooled all
+--      titles together and can't be deconvolved), then replays every approved
+--      video-game submission in created_at order to rebuild per-title ratings.
+--
+-- All non-video systems are unchanged.
+-- ============================================================================
+
+
+-- ---------- 1. NEW COLUMN ----------
+alter table public.elo_ratings
+  add column if not exists video_game_title_id bigint
+  references public.video_game_titles(id) on delete cascade;
+
+create index if not exists idx_elo_video_game on public.elo_ratings(video_game_title_id);
+
+
+-- ---------- 2. REPLACE PK WITH UNIQUE INDEX (NULLS NOT DISTINCT) ----------
+-- Drop the old PK that ignored video_game_title_id. We use a unique index with
+-- NULLS NOT DISTINCT instead of a new PK because PostgreSQL forbids NULLs in
+-- primary key columns, and we want one row per non-video tabletop system to
+-- continue using video_game_title_id = NULL.
+alter table public.elo_ratings
+  drop constraint if exists elo_ratings_pkey;
+
+drop index if exists elo_ratings_unique_idx;
+
+create unique index elo_ratings_unique_idx
+  on public.elo_ratings (user_id, game_system_id, faction_id, video_game_title_id)
+  nulls not distinct;
+
+
+-- ---------- 3. EXTEND get_or_create_elo ----------
+-- Backwards-compatible: existing 3-arg callers continue to work because we
+-- give video_game_title_id a default of NULL, and PostgreSQL resolves the
+-- 4-arg overload only when the caller passes it explicitly.
+create or replace function public.get_or_create_elo(
+  p_user_id            uuid,
+  p_game_system_id     text,
+  p_faction_id         uuid,
+  p_video_game_title_id bigint default null
+) returns int
+language plpgsql security definer as $$
+declare
+  v_rating int;
+  v_start  int;
+begin
+  select rating into v_rating
+  from public.elo_ratings
+  where user_id = p_user_id
+    and game_system_id = p_game_system_id
+    and faction_id = p_faction_id
+    and video_game_title_id is not distinct from p_video_game_title_id;
+
+  if v_rating is null then
+    select coalesce(starting_elo, 1200) into v_start
+    from public.elo_config
+    where game_system_id = p_game_system_id;
+
+    v_start := coalesce(v_start, 1200);
+
+    insert into public.elo_ratings (user_id, game_system_id, faction_id, video_game_title_id, rating)
+    values (p_user_id, p_game_system_id, p_faction_id, p_video_game_title_id, v_start)
+    on conflict do nothing;
+
+    v_rating := v_start;
+  end if;
+
+  return v_rating;
+end;
+$$;
+
+
+-- ---------- 4. REPLACE TRIGGER ----------
+-- Diff vs 0008's version: section 4 now derives a v_vg_id from
+-- new.video_game_title_id when the game system supports video games, and
+-- threads it through every get_or_create_elo and elo_ratings UPDATE in both
+-- the linked and unlinked branches. Non-video systems pass NULL, matching
+-- their existing rows.
+create or replace function public.award_points_on_approval()
+ returns trigger
+ language plpgsql
+ security definer
+as $function$
+declare
+  v_threshold     int;
+  v_current       int;
+  v_submitter_faction uuid;
+  v_top_faction   uuid;
+  v_prev_controller uuid;
+  v_top_contributor uuid;
+  v_sub_rating    int;
+  v_adv_rating    int;
+  v_k             int;
+  v_score         numeric;
+  v_delta_sub     int;
+  v_delta_adv     int;
+  v_prev_status   text;
+  v_mirror_result text;
+  v_mirror_points int;
+  v_supports_vg   boolean;
+  v_vg_id         bigint;
+begin
+  if new.mirror_of is not null then
+    return new;
+  end if;
+
+  v_prev_status := coalesce(old.status, 'pending');
+  v_delta_sub := 0;
+  v_delta_adv := 0;
+  v_mirror_result := null;
+  v_mirror_points := 0;
+
+  if new.status = 'approved' and v_prev_status <> 'approved' then
+
+    v_submitter_faction := new.faction_id;
+    if v_submitter_faction is null then
+      select faction_id into v_submitter_faction
+      from public.profiles where id = new.player_id;
+    end if;
+
+    if new.type = 'game'
+       and new.adversary_user_id is not null
+       and new.adversary_faction_id is not null
+       and new.result is not null then
+      v_mirror_result := public.opposite_result(new.result);
+      if v_mirror_result is not null then
+        select coalesce(ps.points, 0) into v_mirror_points
+        from public.point_schemes ps
+        where ps.game_system_id = new.game_system_id
+          and ps.game_size      = coalesce(new.game_size, 'n/a')
+          and ps.result         = v_mirror_result
+        limit 1;
+        v_mirror_points := coalesce(v_mirror_points, 0);
+      end if;
+    end if;
+
+    -- 1) Submitter glory on planet
+    if new.target_planet_id is not null and v_submitter_faction is not null and coalesce(new.points, 0) > 0 then
+      insert into public.planet_points (planet_id, faction_id, points)
+      values (new.target_planet_id, v_submitter_faction, new.points)
+      on conflict (planet_id, faction_id)
+      do update set points = public.planet_points.points + excluded.points;
+
+      if new.adversary_faction_id is not null
+         and new.adversary_faction_id <> v_submitter_faction
+         and v_mirror_points > 0 then
+
+        insert into public.planet_points (planet_id, faction_id, points)
+        values (new.target_planet_id, new.adversary_faction_id, v_mirror_points)
+        on conflict (planet_id, faction_id)
+        do update set points = public.planet_points.points + excluded.points;
+      end if;
+
+      -- 3) Planet threshold / control flip check + flip log.
+      select threshold, controlling_faction_id
+        into v_threshold, v_prev_controller
+      from public.planets where id = new.target_planet_id;
+
+      select coalesce(max(points),0) into v_current
+      from public.planet_points
+      where planet_id = new.target_planet_id;
+
+      select faction_id into v_top_faction
+      from public.planet_points
+      where planet_id = new.target_planet_id
+      order by points desc
+      limit 1;
+
+      if v_current >= coalesce(v_threshold, 0)
+         and v_top_faction is not null
+         and (v_prev_controller is null or v_prev_controller <> v_top_faction) then
+
+        select s.player_id into v_top_contributor
+        from public.submissions s
+        where s.target_planet_id = new.target_planet_id
+          and s.faction_id       = v_top_faction
+          and s.status            = 'approved'
+        group by s.player_id
+        order by sum(coalesce(s.points, 0)) desc, min(s.created_at) asc, s.player_id asc
+        limit 1;
+
+        update public.planets
+        set controlling_faction_id = v_top_faction,
+            claimed_at = coalesce(claimed_at, now())
+        where id = new.target_planet_id;
+
+        insert into public.planet_flip_log (
+          planet_id, gained_faction_id, lost_faction_id,
+          trigger_submission_id, top_contributor_id, points_at_flip
+        )
+        values (
+          new.target_planet_id, v_top_faction, v_prev_controller,
+          new.id, v_top_contributor, v_current
+        );
+      end if;
+    end if;
+
+    -- 4) ELO update for game submissions.
+    if new.type = 'game'
+       and new.game_system_id is not null
+       and new.result is not null
+       and new.faction_id is not null then
+
+      select coalesce(supports_video_game, false) into v_supports_vg
+      from public.game_systems
+      where id = new.game_system_id;
+      v_supports_vg := coalesce(v_supports_vg, false);
+
+      v_vg_id := case when v_supports_vg then new.video_game_title_id else null end;
+
+      select coalesce(k_factor, 32) into v_k
+      from public.elo_config
+      where game_system_id = new.game_system_id;
+      v_k := coalesce(v_k, 32);
+
+      v_score := case new.result
+        when 'win'  then 1.0
+        when 'draw' then 0.5
+        when 'loss' then 0.0
+      end;
+
+      -- Video games require a title for per-title rating; skip ELO if missing.
+      if not v_supports_vg or v_vg_id is not null then
+
+        if new.adversary_user_id is not null
+           and new.adversary_faction_id is not null then
+
+          v_sub_rating := public.get_or_create_elo(new.player_id,           new.game_system_id, new.faction_id,           v_vg_id);
+          v_adv_rating := public.get_or_create_elo(new.adversary_user_id,   new.game_system_id, new.adversary_faction_id, v_vg_id);
+
+          v_delta_sub := public.calc_elo_delta(v_sub_rating, v_adv_rating, v_score, v_k);
+          v_delta_adv := -v_delta_sub;
+
+          update public.elo_ratings
+            set rating = rating + v_delta_sub,
+                games_played = games_played + 1,
+                wins   = wins   + (case when new.result = 'win'  then 1 else 0 end),
+                losses = losses + (case when new.result = 'loss' then 1 else 0 end),
+                draws  = draws  + (case when new.result = 'draw' then 1 else 0 end),
+                updated_at = now()
+          where user_id = new.player_id
+            and game_system_id = new.game_system_id
+            and faction_id = new.faction_id
+            and video_game_title_id is not distinct from v_vg_id;
+
+          update public.elo_ratings
+            set rating = rating + v_delta_adv,
+                games_played = games_played + 1,
+                wins   = wins   + (case when new.result = 'loss' then 1 else 0 end),
+                losses = losses + (case when new.result = 'win'  then 1 else 0 end),
+                draws  = draws  + (case when new.result = 'draw' then 1 else 0 end),
+                updated_at = now()
+          where user_id = new.adversary_user_id
+            and game_system_id = new.game_system_id
+            and faction_id = new.adversary_faction_id
+            and video_game_title_id is not distinct from v_vg_id;
+
+          new.elo_delta := v_delta_sub;
+          new.adversary_elo_delta := v_delta_adv;
+
+        elsif new.adversary_user_id is null
+              and new.adversary_faction_id is null then
+
+          v_sub_rating := public.get_or_create_elo(new.player_id, new.game_system_id, new.faction_id, v_vg_id);
+
+          select coalesce(starting_elo, 1200) into v_adv_rating
+          from public.elo_config
+          where game_system_id = new.game_system_id;
+          v_adv_rating := coalesce(v_adv_rating, 1200);
+
+          v_delta_sub := public.calc_elo_delta(v_sub_rating, v_adv_rating, v_score, v_k);
+
+          update public.elo_ratings
+            set rating = rating + v_delta_sub,
+                games_played = games_played + 1,
+                wins   = wins   + (case when new.result = 'win'  then 1 else 0 end),
+                losses = losses + (case when new.result = 'loss' then 1 else 0 end),
+                draws  = draws  + (case when new.result = 'draw' then 1 else 0 end),
+                updated_at = now()
+          where user_id = new.player_id
+            and game_system_id = new.game_system_id
+            and faction_id = new.faction_id
+            and video_game_title_id is not distinct from v_vg_id;
+
+          new.elo_delta := v_delta_sub;
+        end if;
+      end if;
+    end if;
+
+    -- 5) Mirror submission for linked battles.
+    if v_mirror_result is not null
+       and not exists (select 1 from public.submissions where mirror_of = new.id) then
+
+      insert into public.submissions (
+        player_id,
+        faction_id,
+        target_planet_id,
+        type,
+        title,
+        body,
+        image_url,
+        opponent_name,
+        result,
+        points,
+        status,
+        reviewed_by,
+        reviewed_at,
+        review_notes,
+        game_system_id,
+        game_size,
+        video_game_title_id,
+        adversary_user_id,
+        adversary_faction_id,
+        elo_delta,
+        adversary_elo_delta,
+        mirror_of
+      ) values (
+        new.adversary_user_id,
+        new.adversary_faction_id,
+        new.target_planet_id,
+        new.type,
+        new.title,
+        new.body,
+        new.image_url,
+        null,
+        v_mirror_result,
+        v_mirror_points,
+        'approved',
+        new.reviewed_by,
+        coalesce(new.reviewed_at, now()),
+        new.review_notes,
+        new.game_system_id,
+        new.game_size,
+        new.video_game_title_id,
+        new.player_id,
+        new.faction_id,
+        v_delta_adv,
+        v_delta_sub,
+        new.id
+      );
+    end if;
+
+    -- 6) Award evaluation.
+    perform public.evaluate_player_awards(new.player_id);
+    if new.adversary_user_id is not null then
+      perform public.evaluate_player_awards(new.adversary_user_id);
+    end if;
+    perform public.evaluate_competitive_awards();
+
+    new.reviewed_at := coalesce(new.reviewed_at, now());
+  end if;
+
+  return new;
+end;
+$function$;
+
+
+-- ---------- 5. BACKFILL ----------
+-- Existing video-system elo_ratings rows pooled every video game together.
+-- We can't deconvolve them, so we wipe them and replay every approved
+-- video-game submission in chronological order to rebuild per-title ratings.
+-- Non-video systems are untouched.
+do $$
+declare
+  s record;
+  v_k          int;
+  v_sub_rating int;
+  v_adv_rating int;
+  v_start      int;
+  v_score      numeric;
+  v_delta_sub  int;
+  v_delta_adv  int;
+begin
+  -- Wipe pooled video-system ratings. Mirror submissions for video games
+  -- share game_system_id = 'video', so we clear the whole partition.
+  delete from public.elo_ratings where game_system_id = 'video';
+
+  -- elo_delta and adversary_elo_delta on the submissions themselves were
+  -- computed against the pooled rating. Zero them out for video matches so
+  -- the David award (which inspects elo_delta) isn't misled by stale values.
+  update public.submissions
+  set elo_delta = 0,
+      adversary_elo_delta = 0
+  where game_system_id = 'video';
+
+  -- Replay video matches in time order. Originals only (mirrors are inserted
+  -- by the trigger; here we mimic that by handling both sides explicitly).
+  select coalesce(k_factor, 32), coalesce(starting_elo, 1200)
+    into v_k, v_start
+  from public.elo_config where game_system_id = 'video';
+  v_k     := coalesce(v_k, 16);
+  v_start := coalesce(v_start, 1200);
+
+  for s in
+    select sub.*
+    from public.submissions sub
+    where sub.status = 'approved'
+      and sub.type = 'game'
+      and sub.game_system_id = 'video'
+      and sub.mirror_of is null
+      and sub.result is not null
+      and sub.faction_id is not null
+      and sub.video_game_title_id is not null
+    order by sub.created_at, sub.id
+  loop
+    v_score := case s.result
+      when 'win'  then 1.0
+      when 'draw' then 0.5
+      when 'loss' then 0.0
+    end;
+
+    if s.adversary_user_id is not null and s.adversary_faction_id is not null then
+      v_sub_rating := public.get_or_create_elo(s.player_id,         'video', s.faction_id,           s.video_game_title_id);
+      v_adv_rating := public.get_or_create_elo(s.adversary_user_id, 'video', s.adversary_faction_id, s.video_game_title_id);
+
+      v_delta_sub := public.calc_elo_delta(v_sub_rating, v_adv_rating, v_score, v_k);
+      v_delta_adv := -v_delta_sub;
+
+      update public.elo_ratings
+        set rating = rating + v_delta_sub,
+            games_played = games_played + 1,
+            wins   = wins   + (case when s.result = 'win'  then 1 else 0 end),
+            losses = losses + (case when s.result = 'loss' then 1 else 0 end),
+            draws  = draws  + (case when s.result = 'draw' then 1 else 0 end),
+            updated_at = now()
+      where user_id = s.player_id
+        and game_system_id = 'video'
+        and faction_id = s.faction_id
+        and video_game_title_id is not distinct from s.video_game_title_id;
+
+      update public.elo_ratings
+        set rating = rating + v_delta_adv,
+            games_played = games_played + 1,
+            wins   = wins   + (case when s.result = 'loss' then 1 else 0 end),
+            losses = losses + (case when s.result = 'win'  then 1 else 0 end),
+            draws  = draws  + (case when s.result = 'draw' then 1 else 0 end),
+            updated_at = now()
+      where user_id = s.adversary_user_id
+        and game_system_id = 'video'
+        and faction_id = s.adversary_faction_id
+        and video_game_title_id is not distinct from s.video_game_title_id;
+
+      update public.submissions
+      set elo_delta = v_delta_sub,
+          adversary_elo_delta = v_delta_adv
+      where id = s.id;
+
+    elsif s.adversary_user_id is null and s.adversary_faction_id is null then
+      v_sub_rating := public.get_or_create_elo(s.player_id, 'video', s.faction_id, s.video_game_title_id);
+      v_delta_sub  := public.calc_elo_delta(v_sub_rating, v_start, v_score, v_k);
+
+      update public.elo_ratings
+        set rating = rating + v_delta_sub,
+            games_played = games_played + 1,
+            wins   = wins   + (case when s.result = 'win'  then 1 else 0 end),
+            losses = losses + (case when s.result = 'loss' then 1 else 0 end),
+            draws  = draws  + (case when s.result = 'draw' then 1 else 0 end),
+            updated_at = now()
+      where user_id = s.player_id
+        and game_system_id = 'video'
+        and faction_id = s.faction_id
+        and video_game_title_id is not distinct from s.video_game_title_id;
+
+      update public.submissions
+      set elo_delta = v_delta_sub
+      where id = s.id;
+    end if;
+  end loop;
+end $$;


### PR DESCRIPTION
## Summary
- **Fixes #49** — Splits video-game ELO out by individual title (Dawn of War, Battlesector, etc.) instead of pooling every video game under a single `video` system rating. Adds `video_game_title_id` to `elo_ratings`, threads it through `get_or_create_elo` and the approval trigger, and replays existing approved video matches in time order to rebuild per-title ratings. Dashboard and player-profile ELO tables now show the video game title.
- **Fixes #48** — Admin approval queue can now edit planet, game system, battle size, video game title, opponent name, and adversary linking for game-type submissions, alongside the existing point/type/faction overrides. Changing the planet snaps the system to one allowed there; changing the system clears stale size/video-title selections.

## Migration
`supabase/migrations/0015_video_game_per_title_elo.sql` has already been applied to the linked Supabase project (`agdeqbdsgjccawizbwvz`). Backfill replayed cleanly: the previously-pooled video rating now sits under Dawn of War.

## Test plan
- [x] Submit a video-game battle for a *different* title (e.g. Battlesector); confirm a new `elo_ratings` row appears with that title rather than merging with the Dawn of War rating.
- [x] Submit a tabletop battle; confirm `video_game_title_id` stays NULL and rating updates as before.
- [x] In the admin queue, change the planet on a pending game submission and verify the system selector snaps to an allowed system.
- [x] In the admin queue, change game system from a video system to a tabletop system; confirm the video-game-title field disappears and is cleared on save.
- [x] In the admin queue, link an unlinked adversary on a pending battle; approve and confirm the mirror submission + both-sides ELO update fire.
- [x] Dashboard + player profile ELO tables show the video game title rather than just "Video Game".

🤖 Generated with [Claude Code](https://claude.com/claude-code)